### PR TITLE
Fix CI workflow: correct pytest path and coverage source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,6 @@ jobs:
 
       - name: Run tests with coverage
         run: |
-          coverage run --concurrency=thread --parallel-mode -m pytest -q ./src
+          coverage run --source=hklpy2_solvers --concurrency=thread --parallel-mode -m pytest -q
           coverage combine
           coverage report --precision 3 -m


### PR DESCRIPTION
- closes #11

## Summary

- Remove explicit `./src` path argument from `pytest` so it uses
  `testpaths = ["tests"]` from `pyproject.toml`
- Add `--source=hklpy2_solvers` to `coverage run` so the module is
  tracked

Agent: OpenCode (claudeopus46)