### PR TITLE
Fix PyPI workflow trigger: build on main, publish on tags

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,8 +1,9 @@
 name: Publish to PyPI
 
 on:
-  release:
-    types: [published]
+  push:
+    branches: [main]
+    tags: ["v*"]
 
 permissions:
   id-token: write
@@ -33,6 +34,7 @@ jobs:
           path: dist/
 
   publish:
+    if: startsWith(github.ref, 'refs/tags/v')
     needs: build
     runs-on: ubuntu-latest
     environment: pypi

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -35,3 +35,16 @@ describe future plans.
 
     * Add ``diffcalc`` solver adapter wrapping diffcalc-core (You 1999,
       4S+2D six-circle geometry).  :issue:`2`
+
+    Fixes
+    ~~~~~
+
+    * Fix CI workflow: pytest path and coverage source.  :issue:`11`
+    * Fix PyPI publish workflow trigger.  :issue:`13`
+
+    Maintenance
+    ~~~~~~~~~~~
+
+    * Add CI workflow (pytest on Python 3.10--3.13, ruff lint/format).
+    * Add PyPI trusted publishing workflow.
+    * Add dependabot for GitHub Actions and pip dependencies.


### PR DESCRIPTION
- closes #13

## Summary

- Trigger on `push` to `main` (build job only, verifies the package builds)
- Trigger on `push` of `v*` tags (build + publish to PyPI)
- Publish job gated with `if: startsWith(github.ref, 'refs/tags/v')`

Replaces the `release: published` trigger which never fired because
pushing a tag does not create a GitHub Release.

Agent: OpenCode (claudeopus46)