### PR TITLE
fix #17 add axes_w; correct extra_axis_names and extras

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -23,21 +23,32 @@ Brief notes describing each release and what's new.
 Project `milestones <https://github.com/prjemian/hklpy2_solvers/milestones>`_
 describe future plans.
 
+.. comment
+
+    0.1.6
+    #####
+
+    Release expected TBD.
+
+    Fixes
+    ~~~~~
+
+    * Fix ``extra_axis_names`` and ``extras``: always ``[]``/``{}`` (no
+      non-motor extra parameters in this geometry).  Add ``axes_w`` property
+      so hklpy2 can identify axes computed by ``forward()`` and enable the
+      presets feature for constant axes.  :issue:`17`
+    * Fix usage documentation: use ``hklpy2.creator()`` as the standard entry
+      point; describe all solvers generically.  :issue:`18`
+
 0.1.5
 #####
 
 Released 2026-04-13.
 
-    Fixes
-    ~~~~~
+New Features
+~~~~~~~~~~~~
 
-    * Fix usage documentation: use ``hklpy2.creator()`` as the standard entry
-      point; describe all solvers generically.  :issue:`18`
-
-    New Features
-    ~~~~~~~~~~~~
-
-    * Add Sphinx documentation framework with versioned GitHub Pages deployment.  :issue:`15`
+* Add Sphinx documentation framework with versioned GitHub Pages deployment.  :issue:`15`
 
 0.1.4
 #####

--- a/docs/source/geometries.rst
+++ b/docs/source/geometries.rst
@@ -37,8 +37,10 @@ Operating modes
 ~~~~~~~~~~~~~~~
 
 The diffcalc solver selects three diffractometer constraints to fix for
-each operating mode.  The default constraint values (typically zero) can
-be overridden via the solver's ``extras`` dictionary.
+each operating mode.  This geometry has no extra parameters
+(``extras`` is always ``{}``).  The axes computed by ``forward()``
+(``axes_w``) are all real axes not listed as fixed constraints; the
+remaining axes are held constant (``axes_c``, derived by hklpy2).
 
 .. list-table::
    :header-rows: 1

--- a/src/hklpy2_solvers/diffcalc_solver.py
+++ b/src/hklpy2_solvers/diffcalc_solver.py
@@ -98,8 +98,12 @@ class DiffcalcSolver(SolverBase):
     diffractometer with axes ``mu, delta, nu, eta, chi, phi``.
 
     Operating modes correspond to specific three-constraint combinations
-    understood by diffcalc.  The default constraint *values* (typically
-    zero) can be changed via :attr:`extras`.
+    understood by diffcalc.
+
+    This geometry has no extra parameters (``extras`` is always ``{}``).
+    The :attr:`axes_w` property reports which real axes are computed by
+    :meth:`forward` in the current mode; the remaining real axes are held
+    constant (``axes_c``, derived by hklpy2's ``Core`` class).
     """
 
     name = "diffcalc"
@@ -113,7 +117,6 @@ class DiffcalcSolver(SolverBase):
 
         # Initialize internal state *before* super().__init__ which
         # may set mode via the setter.
-        self._extras: dict[str, Any] = {}
         self._ubcalc = UBCalculation("default")
         self._constraints = Constraints()
         self._hklcalc: HklCalculation | None = None
@@ -136,15 +139,10 @@ class DiffcalcSolver(SolverBase):
         self._hklcalc = HklCalculation(self._ubcalc, self._constraints)
 
     def _apply_mode_constraints(self) -> None:
-        """Set diffcalc constraints from the current mode and extras."""
+        """Set diffcalc constraints from the current mode."""
         if not self.mode:
             return
-        template = _MODES[self.mode]
-        con_dict: dict[str, Any] = {}
-        for cname, default_value in template.items():
-            # Allow extras to override the default fixed values.
-            con_dict[cname] = self._extras.get(cname, default_value)
-        self._constraints = Constraints(con_dict)
+        self._constraints = Constraints(_MODES[self.mode])
         self._rebuild_hklcalc()
 
     def _position_from_reals(self, reals: NamedFloatDict) -> Position:
@@ -203,18 +201,34 @@ class DiffcalcSolver(SolverBase):
         return ub.tolist()
 
     @property
-    def extra_axis_names(self) -> list[str]:
-        """Extra parameter names for the current mode's adjustable constraints."""
+    def axes_w(self) -> list[str]:
+        """Real axis names computed by :meth:`forward` in the current mode.
+
+        These are the real axes *not* constrained to a fixed motor position
+        by the current mode.  hklpy2's ``Core`` class derives ``axes_c``
+        (constant axes) and ``axes_r`` (all real axes) from this list and
+        :attr:`real_axis_names`.
+        """
         if not self.mode:
-            return []
-        template = _MODES.get(self.mode, {})
-        # Only numeric (non-bool) constraints are user-adjustable extras.
-        return [k for k, v in template.items() if isinstance(v, (int, float)) and not isinstance(v, bool)]
+            return list(REAL_AXES)
+        constrained_motors = set(_MODES[self.mode].keys()) & set(REAL_AXES)
+        return [ax for ax in REAL_AXES if ax not in constrained_motors]
+
+    @property
+    def extra_axis_names(self) -> list[str]:
+        """Extra parameter names beyond the real motor axes.
+
+        This geometry has no extra parameters; always returns ``[]``.
+        """
+        return []
 
     @property
     def extras(self) -> dict[str, Any]:
-        """Current extra parameter values (adjustable constraint values)."""
-        return dict(self._extras)
+        """Extra parameters beyond the real motor axes.
+
+        This geometry has no extra parameters; always returns ``{}``.
+        """
+        return {}
 
     def forward(self, pseudos: NamedFloatDict) -> list[NamedFloatDict]:
         """Compute motor positions from pseudo-axis values (hkl -> angles)."""
@@ -292,14 +306,8 @@ class DiffcalcSolver(SolverBase):
 
         check_value_in_list("Mode", value, self.modes, blank_ok=True)
         self._mode = value
-        # Reset extras to mode defaults when mode changes.
         if value and value in _MODES:
-            self._extras = {
-                k: v for k, v in _MODES[value].items() if isinstance(v, (int, float)) and not isinstance(v, bool)
-            }
             self._apply_mode_constraints()
-        else:
-            self._extras = {}
 
     @property
     def modes(self) -> list[str]:

--- a/tests/test_diffcalc_solver.py
+++ b/tests/test_diffcalc_solver.py
@@ -414,28 +414,19 @@ def test_forward_inverse_roundtrip(parms, context):
     "parms, context",
     [
         pytest.param(
-            dict(
-                mode="4S+2D mu_chi_phi_fixed",
-                expected_extras=["mu", "chi", "phi"],
-            ),
+            dict(mode="4S+2D mu_chi_phi_fixed"),
             does_not_raise(),
-            id="3-sample mode extras",
+            id="extra_axis_names is always empty",
         ),
         pytest.param(
-            dict(
-                mode="4S+2D mu_fixed a_eq_b delta_fixed",
-                expected_extras=["delta", "mu"],
-            ),
+            dict(mode="4S+2D mu_fixed a_eq_b delta_fixed"),
             does_not_raise(),
-            id="det+ref+samp mode extras exclude a_eq_b",
+            id="extra_axis_names empty for det+ref+samp mode",
         ),
         pytest.param(
-            dict(
-                mode="4S+2D bisect_mu_fixed delta_fixed",
-                expected_extras=["delta", "mu"],
-            ),
+            dict(mode=""),
             does_not_raise(),
-            id="bisect mode extras exclude bisect",
+            id="extra_axis_names empty for empty mode",
         ),
     ],
 )
@@ -443,7 +434,52 @@ def test_extra_axis_names(parms, context):
     solver = DiffcalcSolver()
     with context:
         solver.mode = parms["mode"]
-        assert sorted(solver.extra_axis_names) == sorted(parms["expected_extras"])
+        assert solver.extra_axis_names == []
+        assert solver.extras == {}
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(
+                mode="4S+2D mu_chi_phi_fixed",
+                expected_axes_w=["delta", "nu", "eta"],
+            ),
+            does_not_raise(),
+            id="axes_w excludes mu, chi, phi",
+        ),
+        pytest.param(
+            dict(
+                mode="4S+2D mu_fixed a_eq_b delta_fixed",
+                expected_axes_w=["nu", "eta", "chi", "phi"],
+            ),
+            does_not_raise(),
+            id="axes_w excludes mu and delta",
+        ),
+        pytest.param(
+            dict(
+                mode="4S+2D chi_phi_fixed delta_fixed",
+                expected_axes_w=["mu", "nu", "eta"],
+            ),
+            does_not_raise(),
+            id="axes_w excludes chi, phi, delta",
+        ),
+        pytest.param(
+            dict(
+                mode="",
+                expected_axes_w=REAL_AXES,
+            ),
+            does_not_raise(),
+            id="axes_w returns all axes when mode is empty",
+        ),
+    ],
+)
+def test_axes_w(parms, context):
+    solver = DiffcalcSolver()
+    with context:
+        solver.mode = parms["mode"]
+        assert solver.axes_w == parms["expected_axes_w"]
 
 
 @pytest.mark.parametrize(
@@ -637,22 +673,6 @@ def test_refine_lattice_insufficient_reflections(parms, context):
         assert result is None
 
 
-@pytest.mark.parametrize(
-    "parms, context",
-    [
-        pytest.param(
-            dict(),
-            does_not_raise(),
-            id="empty mode gives empty extra_axis_names",
-        ),
-    ],
-)
-def test_extra_axis_names_empty_mode(parms, context):
-    solver = DiffcalcSolver()
-    solver._mode = ""
-    with context:
-        assert solver.extra_axis_names == []
-
 
 @pytest.mark.parametrize(
     "parms, context",
@@ -738,4 +758,4 @@ def test_mode_set_empty(parms, context):
     with context:
         solver.mode = parms["mode"]
         assert solver.mode == ""
-        assert solver._extras == {}
+        assert solver.extras == {}

--- a/tests/test_diffcalc_solver.py
+++ b/tests/test_diffcalc_solver.py
@@ -673,7 +673,6 @@ def test_refine_lattice_insufficient_reflections(parms, context):
         assert result is None
 
 
-
 @pytest.mark.parametrize(
     "parms, context",
     [


### PR DESCRIPTION
- closes #17

## Summary

- Add ``axes_w`` property: returns the real axes computed by ``forward()`` in the current mode (all real axes not constrained as fixed motor positions). hklpy2's ``Core`` class uses this to derive ``axes_c`` (constant axes) and to drive the presets feature — no further solver changes needed for presets to work.
- Fix ``extra_axis_names``: always returns ``[]``. This geometry has no non-motor extra parameters; ``psi`` and ``omega`` that appear in some mode constraint dicts are diffcalc internal pseudo-angles, not hklpy2 extras.
- Fix ``extras``: always returns ``{}``.
- Remove ``_extras`` internal dict and the ``mode.setter`` logic that populated it with motor axis values.
- Simplify ``_apply_mode_constraints``: applies mode constraints directly, no extras override needed.
- Update tests: correct ``test_extra_axis_names`` to assert ``[]``/``{}``, remove ``test_extra_axis_names_empty_mode`` (folded in), add ``test_axes_w`` with parametrized cases, fix ``test_mode_set_empty`` to use public ``extras`` property.
- Update ``geometries.rst``: remove incorrect statement about overriding constraint values via ``extras``.
- Update ``RELEASE_NOTES.rst``: move pending entry to 0.1.6 block; fix 0.1.5 subsection indentation.

Agent: OpenCode (claudesonnet46)