### PR TITLE
fix #25 override sample setter to push lattice into diffcalc UBCalculation

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -31,15 +31,12 @@ describe future plans.
 Fixes
 ~~~~~
 
-* Fix ``calc_UB()`` failing with ``SolverError: Lattice must be set`` even
-  when the sample has a lattice.  Override ``sample`` setter to push the
-  lattice (and reflections) from the hklpy2 sample dict into diffcalc's
-  ``UBCalculation`` immediately, mirroring ``HklSolver`` behaviour.
-  :issue:`25`
-* Fix ``wh()`` (and ``inverse()``) failing with ``SolverError: UB matrix has
-  not been set`` immediately after diffractometer creation.  A default identity
-  UB is now initialised automatically for the ``inverse`` path; ``forward``
-  still requires an explicit orientation.  :issue:`24`
+* Fix ``calc_UB()`` raising ``SolverError: Lattice must be set`` even when
+  the sample has a lattice; override ``sample`` setter to push lattice and
+  reflections into diffcalc immediately.  :issue:`25`
+* Fix ``wh()`` raising ``SolverError: UB matrix has not been set`` before
+  any reflections are added; auto-init a default UB for ``inverse()``.
+  :issue:`24`
 
 0.1.6
 #####

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -31,6 +31,11 @@ describe future plans.
 Fixes
 ~~~~~
 
+* Fix ``calc_UB()`` failing with ``SolverError: Lattice must be set`` even
+  when the sample has a lattice.  Override ``sample`` setter to push the
+  lattice (and reflections) from the hklpy2 sample dict into diffcalc's
+  ``UBCalculation`` immediately, mirroring ``HklSolver`` behaviour.
+  :issue:`25`
 * Fix ``wh()`` (and ``inverse()``) failing with ``SolverError: UB matrix has
   not been set`` immediately after diffractometer creation.  A default identity
   UB is now initialised automatically for the ``inverse`` path; ``forward``

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -31,12 +31,8 @@ describe future plans.
 Fixes
 ~~~~~
 
-* Fix ``calc_UB()`` raising ``SolverError: Lattice must be set`` even when
-  the sample has a lattice; override ``sample`` setter to push lattice and
-  reflections into diffcalc immediately.  :issue:`25`
-* Fix ``wh()`` raising ``SolverError: UB matrix has not been set`` before
-  any reflections are added; auto-init a default UB for ``inverse()``.
-  :issue:`24`
+* Fix ``calc_UB()`` raising ``SolverError: Lattice must be set``; override ``sample`` setter to push lattice into diffcalc.  :issue:`25`
+* Fix ``wh()`` raising ``SolverError: UB matrix has not been set`` before reflections are added.  :issue:`24`
 
 0.1.6
 #####

--- a/src/hklpy2_solvers/diffcalc_solver.py
+++ b/src/hklpy2_solvers/diffcalc_solver.py
@@ -334,6 +334,43 @@ class DiffcalcSolver(SolverBase):
 
         self._ubcalc.set_lattice("sample", a, b, c, alpha, beta, gamma)
 
+    @SolverBase.sample.setter
+    def sample(self, value: dict) -> None:
+        """Set the crystalline sample, pushing lattice and reflections into diffcalc.
+
+        Overrides :class:`~hklpy2.backends.base.SolverBase` to mirror the
+        pattern used by ``HklSolver``: after storing the dict, the lattice is
+        immediately pushed into :attr:`_ubcalc` and all reflections are
+        re-added in ``order`` sequence.  This ensures that
+        :meth:`calculate_UB` can find a crystal when called by
+        ``hklpy2.Core.calc_UB()`` (fixes :issue:`25`).
+        """
+        if not isinstance(value, dict):
+            raise TypeError(f"Must supply dictionary, received {value!r}")
+        self._sample = value
+
+        # Push lattice into diffcalc immediately (mirrors HklSolver behaviour).
+        if "lattice" in value:
+            self.lattice = value["lattice"]
+
+        # Re-populate diffcalc's reflection list in the declared order so that
+        # calc_ub() uses the correct pair.
+        # reflections may be a list or a dict keyed by name.
+        raw = value.get("reflections", [])
+        if isinstance(raw, dict):
+            refl_by_name: dict = raw
+        else:
+            refl_by_name = {r["name"]: r for r in raw}
+
+        self._reflections.clear()
+        self._ubcalc = UBCalculation("default")
+        if self._lattice:
+            # Re-apply lattice after UBCalculation reset.
+            self.lattice = self._lattice
+        for name in value.get("order", []):
+            if name in refl_by_name:
+                self.addReflection(refl_by_name[name])
+
     @property
     def mode(self) -> str:
         """Current operating mode."""

--- a/tests/test_diffcalc_solver.py
+++ b/tests/test_diffcalc_solver.py
@@ -817,3 +817,139 @@ def test_inverse_default_ub_idempotent(parms, context):
         r2 = solver.inverse(parms["reals"])
         for axis in ("h", "k", "l"):
             assert r1[axis] == r2[axis]
+
+
+# ---------------------------------------------------------------------------
+# Issue #25 regression tests: sample setter pushes lattice into diffcalc
+# ---------------------------------------------------------------------------
+
+# A minimal SampleDict as produced by hklpy2 Core.to_solver_units()
+_SAMPLE_DICT_LIST_REFLECTIONS = {
+    "name": "vibranium",
+    "lattice": {
+        "a": SI_A,
+        "b": SI_A,
+        "c": SI_A,
+        "alpha": 90.0,
+        "beta": 90.0,
+        "gamma": 90.0,
+        "angle_units": "degrees",
+        "length_units": "angstrom",
+    },
+    "order": ["r1", "r2"],
+    "reflections": [
+        {
+            "name": "r1",
+            "pseudos": {"h": 1.0, "k": 0.0, "l": 0.0},
+            "reals": {"mu": 0, "delta": TTH_100, "nu": 0, "eta": THETA_100, "chi": 0, "phi": 0},
+            "wavelength": WAVELENGTH,
+        },
+        {
+            "name": "r2",
+            "pseudos": {"h": 0.0, "k": 1.0, "l": 0.0},
+            "reals": {"mu": 0, "delta": TTH_100, "nu": 0, "eta": THETA_100, "chi": 0, "phi": 90},
+            "wavelength": WAVELENGTH,
+        },
+    ],
+}
+
+_SAMPLE_DICT_DICT_REFLECTIONS = {
+    "name": "vibranium",
+    "lattice": {
+        "a": SI_A,
+        "b": SI_A,
+        "c": SI_A,
+        "alpha": 90.0,
+        "beta": 90.0,
+        "gamma": 90.0,
+    },
+    "order": ["r1", "r2"],
+    "reflections": {
+        "r1": {
+            "name": "r1",
+            "pseudos": {"h": 1.0, "k": 0.0, "l": 0.0},
+            "reals": {"mu": 0, "delta": TTH_100, "nu": 0, "eta": THETA_100, "chi": 0, "phi": 0},
+            "wavelength": WAVELENGTH,
+        },
+        "r2": {
+            "name": "r2",
+            "pseudos": {"h": 0.0, "k": 1.0, "l": 0.0},
+            "reals": {"mu": 0, "delta": TTH_100, "nu": 0, "eta": THETA_100, "chi": 0, "phi": 90},
+            "wavelength": WAVELENGTH,
+        },
+    },
+}
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(sample=_SAMPLE_DICT_LIST_REFLECTIONS),
+            does_not_raise(),
+            id="sample setter with list reflections pushes lattice - issue #25",
+        ),
+        pytest.param(
+            dict(sample=_SAMPLE_DICT_DICT_REFLECTIONS),
+            does_not_raise(),
+            id="sample setter with dict reflections pushes lattice",
+        ),
+        pytest.param(
+            dict(sample="not a dict"),
+            pytest.raises(TypeError, match=re.escape("Must supply dictionary")),
+            id="sample setter with non-dict raises TypeError",
+        ),
+    ],
+)
+def test_sample_setter_pushes_lattice(parms, context):
+    """sample setter must push the lattice into _ubcalc (issue #25 regression)."""
+    solver = DiffcalcSolver()
+    with context:
+        solver.sample = parms["sample"]
+        # Lattice must now be in _ubcalc (crystal is not None)
+        assert solver._ubcalc.crystal is not None
+        # The solver's lattice dict must match
+        assert abs(solver.lattice["a"] - SI_A) < 1e-9
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(sample=_SAMPLE_DICT_LIST_REFLECTIONS),
+            does_not_raise(),
+            id="calculate_UB succeeds after sample setter - issue #25",
+        ),
+    ],
+)
+def test_calculate_ub_after_sample_setter(parms, context):
+    """calculate_UB must succeed when lattice arrives via sample setter (issue #25)."""
+    solver = DiffcalcSolver()
+    solver.wavelength = WAVELENGTH
+    with context:
+        solver.sample = parms["sample"]
+        r1 = parms["sample"]["reflections"][0]
+        r2 = parms["sample"]["reflections"][1]
+        ub = solver.calculate_UB(r1, r2)
+        assert len(ub) == 3
+        assert all(len(row) == 3 for row in ub)
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(sample=_SAMPLE_DICT_LIST_REFLECTIONS),
+            does_not_raise(),
+            id="sample setter re-adds reflections in order",
+        ),
+    ],
+)
+def test_sample_setter_repopulates_reflections(parms, context):
+    """sample setter must re-add reflections so _reflections is populated."""
+    solver = DiffcalcSolver()
+    with context:
+        solver.sample = parms["sample"]
+        assert len(solver._reflections) == len(parms["sample"]["order"])
+        for i, name in enumerate(parms["sample"]["order"]):
+            assert solver._reflections[i]["name"] == name


### PR DESCRIPTION
- closes #25

## Summary

- `calc_UB()` raised `SolverError: Lattice must be set` even when the sample had a lattice, because `DiffcalcSolver` inherited the base-class `sample` setter which only stored the dict without pushing the lattice into diffcalc's `UBCalculation`.
- Override `sample.setter` to mirror `HklSolver`: push `value["lattice"]` into `_ubcalc` and re-populate reflections in order.
- Added regression tests for the setter behaviour.

Agent: OpenCode (claudesonnet46)