### PR TITLE
fix #29 add set_reals(), UB setter, change default mode

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -31,8 +31,14 @@ describe future plans.
 Fixes
 ~~~~~
 
+* Fix ``forward()`` raising ``AttributeError: no attribute 'set_reals'``; add ``set_reals()`` and ``UB`` setter, change default mode to ``4S+2D mu_chi_phi_fixed``.  :issue:`29`
 * Fix ``calc_UB()`` raising ``SolverError: Lattice must be set``; override ``sample`` setter to push lattice into diffcalc.  :issue:`25`
 * Fix ``wh()`` raising ``SolverError: UB matrix has not been set`` before reflections are added.  :issue:`24`
+
+Maintenance
+~~~~~~~~~~~
+
+* Document mode naming convention, bisector mode analysis, and extensibility limits in ``geometries.rst``.  :issue:`29`
 
 0.1.6
 #####

--- a/docs/source/geometries.rst
+++ b/docs/source/geometries.rst
@@ -93,4 +93,54 @@ remaining axes are held constant (``axes_c``, derived by hklpy2).
    * - ``4S+2D mu_eta_phi_fixed``
      - mu=0, eta=0, phi=0
    * - ``4S+2D mu_eta_chi_fixed``
-     - mu=0, eta=0, chi=0
+      - mu=0, eta=0, chi=0
+
+Default mode
+~~~~~~~~~~~~
+
+The default mode is ``4S+2D mu_chi_phi_fixed`` (mu=0, chi=0, phi=0).  This is
+a 3-sample mode with no reference-vector constraints, making it robust for the
+widest range of reflections.  It is equivalent to a basic 4-circle geometry
+operating in the vertical scattering plane.
+
+.. note:: **Why not a bisector mode?**
+
+   Following You (1999) Figure 1 (see also
+   `diffcalc-core docs <https://diffcalc-core.readthedocs.io>`_),
+   ``nu`` rotates about the vertical axis and swings the detector
+   **horizontally**; ``delta`` rotates about the horizontal axis and swings
+   the detector **vertically**.
+
+   A ``bissector_vertical`` equivalent (E6C terminology) would require
+   ``bisect=True`` + ``mu=0`` + ``nu=0``, but that combination is not among
+   diffcalc's available modes.  A ``bissector_horizontal`` equivalent would
+   require a ``mu = nu/2`` bisector condition; diffcalc's ``bisect`` constraint
+   implements only ``eta = delta/2`` (vertical bisector), so that is also
+   unavailable.
+
+Mode naming convention
+~~~~~~~~~~~~~~~~~~~~~~
+
+All mode names follow the pattern ``4S+2D <constraints>``, where ``4S+2D``
+identifies the You (1999) geometry and the suffix encodes the three fixed
+constraints:
+
+- ``<axis>_fixed`` or ``<ax1>_<ax2>_fixed`` — motor axis (or axes) fixed at
+  zero.
+- ``a_eq_b`` — reference-vector constraint: azimuthal reference equals
+  scattering vector direction.  **Caution:** singular when the scattering
+  vector is parallel to the reference vector; avoid as a default.
+- ``bisect`` — bisector condition: ``eta = delta/2``.  Implements the vertical
+  bisector only; no horizontal bisector equivalent exists in diffcalc.
+- ``psi_fixed``, ``omega_fixed`` — azimuthal or omega angle fixed at zero.
+
+Extensibility
+~~~~~~~~~~~~~
+
+The available constraint names are fixed by diffcalc-core and cannot be
+changed without modifying that library.  Each constraint name has specific
+mathematical implementation inside diffcalc-core's solver — the name is merely
+a handle for the underlying algebra that reduces the degrees of freedom during
+position calculation.  A new constraint (e.g. ``mu = nu/2``) would require
+new code in diffcalc-core, not just a new entry in ``_MODES``.  From the
+user's perspective the mode list is not extensible.

--- a/src/hklpy2_solvers/diffcalc_solver.py
+++ b/src/hklpy2_solvers/diffcalc_solver.py
@@ -127,8 +127,11 @@ class DiffcalcSolver(SolverBase):
         super().__init__(geometry, **kwargs)
 
         # Apply default mode if none was set via kwargs.
+        # Use mu_chi_phi_fixed: a 3-sample mode with no reference-vector
+        # constraints, robust for most reflections.  See geometries.rst for
+        # why bisector modes are not suitable as a default.
         if not self.mode and self.modes:
-            self.mode = self.modes[0]
+            self.mode = "4S+2D mu_chi_phi_fixed"
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -404,6 +407,27 @@ class DiffcalcSolver(SolverBase):
         """Ordered list of real axis names."""
         return list(REAL_AXES)
 
+    def set_reals(self, reals: NamedFloatDict) -> None:
+        """Set current real-axis values (used by the presets feature).
+
+        Called by ``hklpy2.Core.forward()`` before :meth:`forward` to push
+        constant-axis values into the solver.  For diffcalc, constant axes are
+        encoded in the :class:`~diffcalc.hkl.constraints.Constraints` object
+        rather than in a geometry state, so this method only validates the
+        input and is otherwise a no-op.
+
+        .. note::
+            ``set_reals`` is not yet part of
+            :class:`~hklpy2.backends.base.SolverBase`; it was introduced via
+            the hklpy2 presets feature and is currently only defined on
+            ``HklSolver``.  Tracked upstream as
+            `bluesky/hklpy2#347 <https://github.com/bluesky/hklpy2/issues/347>`_.
+        """
+        if not isinstance(reals, dict):
+            raise TypeError(f"Must supply dict, received {reals!r}")
+        if not all(isinstance(v, (int, float)) for v in reals.values()):
+            raise TypeError(f"All values must be numbers.  Received: {reals!r}")
+
     def refineLattice(self, reflections: list[ReflectionDict]) -> NamedFloatDict | None:
         """Refine lattice parameters from stored reflections."""
         if len(self._reflections) < 3:
@@ -439,6 +463,23 @@ class DiffcalcSolver(SolverBase):
         if self._ubcalc.UB is not None:
             return self._ubcalc.UB.tolist()
         return [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
+
+    @UB.setter
+    def UB(self, value: Matrix3x3) -> None:
+        """Restore the orientation matrix into diffcalc's UBCalculation.
+
+        Called by ``hklpy2.Core.update_solver()`` after ``sample`` is set, to
+        restore the previously computed UB so that :meth:`forward` and
+        :meth:`inverse` use the correct orientation.
+        """
+        if self._ubcalc.crystal is None:
+            # Need a lattice before set_ub will work; use the stored one.
+            if self._lattice:
+                self.lattice = self._lattice
+            else:
+                self._ubcalc.set_lattice("default", 1.0, 1.0, 1.0, 90.0, 90.0, 90.0)
+        self._ubcalc.set_ub(value)
+        self._rebuild_hklcalc()
 
     @property
     def wavelength(self) -> float | None:

--- a/tests/test_diffcalc_solver.py
+++ b/tests/test_diffcalc_solver.py
@@ -953,3 +953,85 @@ def test_sample_setter_repopulates_reflections(parms, context):
         assert len(solver._reflections) == len(parms["sample"]["order"])
         for i, name in enumerate(parms["sample"]["order"]):
             assert solver._reflections[i]["name"] == name
+
+
+# ---------------------------------------------------------------------------
+# Issue #29 regression tests: set_reals and UB setter
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(reals={"mu": 0.0, "delta": 0.0, "nu": 0.0, "eta": 0.0, "chi": 0.0, "phi": 0.0}),
+            does_not_raise(),
+            id="set_reals accepts valid dict of floats",
+        ),
+        pytest.param(
+            dict(reals={"mu": 0, "delta": 0, "nu": 0, "eta": 0, "chi": 0, "phi": 0}),
+            does_not_raise(),
+            id="set_reals accepts ints",
+        ),
+        pytest.param(
+            dict(reals="not a dict"),
+            pytest.raises(TypeError, match=re.escape("Must supply dict")),
+            id="set_reals with non-dict raises TypeError",
+        ),
+        pytest.param(
+            dict(reals={"mu": "bad", "delta": 0.0, "nu": 0.0, "eta": 0.0, "chi": 0.0, "phi": 0.0}),
+            pytest.raises(TypeError, match=re.escape("All values must be numbers")),
+            id="set_reals with non-numeric value raises TypeError",
+        ),
+    ],
+)
+def test_set_reals(parms, context):
+    """set_reals validates input and is otherwise a no-op for diffcalc (issue #29)."""
+    solver = DiffcalcSolver()
+    with context:
+        solver.set_reals(parms["reals"])
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(ub=[[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
+            does_not_raise(),
+            id="UB setter restores identity matrix",
+        ),
+    ],
+)
+def test_ub_setter(parms, context):
+    """UB setter must restore the orientation matrix into _ubcalc (issue #29)."""
+    solver = _make_solver_with_ub()
+    with context:
+        solver.UB = parms["ub"]
+        assert solver._ubcalc.UB is not None
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(mode="4S+2D mu_chi_phi_fixed", pseudos={"h": 1.0, "k": 0.0, "l": 0.0}),
+            does_not_raise(),
+            id="forward succeeds after update_solver restores UB via setter - issue #29",
+        ),
+    ],
+)
+def test_forward_after_ub_restore(parms, context):
+    """forward() must work after update_solver() restores UB via the UB setter."""
+    solver = _make_solver_with_ub(mode=parms["mode"])
+    # Simulate what update_solver() does: reset via sample then restore UB
+    ub = solver.UB
+    solver.sample = {
+        "name": "test",
+        "lattice": dict(SI_LATTICE),
+        "order": [],
+        "reflections": [],
+    }
+    solver.UB = ub  # restore, as update_solver() does
+    with context:
+        solutions = solver.forward(parms["pseudos"])
+        assert len(solutions) >= 1


### PR DESCRIPTION
- closes #29

## Summary

- Add ``set_reals()`` — validating no-op; diffcalc encodes constant axes in ``Constraints``, not geometry state.  Upstream gap filed as `bluesky/hklpy2#347`.
- Add ``UB`` setter so ``update_solver()`` can restore the computed orientation matrix after resetting the sample.  Upstream gap filed as `bluesky/hklpy2#348`.
- Change default mode to ``4S+2D mu_chi_phi_fixed``: no reference-vector constraints, robust for all reflections.
- Document mode naming convention, bisector mode analysis, and extensibility limits in ``geometries.rst``.

Agent: OpenCode (claudesonnet46)