### PR TITLE
Fix ModuleNotFoundError: No module named 'hklpy2.misc'

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,8 +147,19 @@ PRs opened or modified by automated agents must follow the "Agent pytest style" 
 
 - Setup: create virtualenv, `pip install -e .[all]`
 - Common commands:
-  - Format & Lint: `make style` or `pre-commit run --all-files`
-  - Test: `pytest ./src`
+  - Format & Lint: `pre-commit run --all-files` (preferred; see note below)
+  - Test: `pytest ./tests`
+
+### `make style` vs `pre-commit run --all-files`
+
+`make style` runs `isort --sl` before `pre-commit`.  `isort --sl` (single-line
+mode) and ruff's built-in isort (`I` rule) disagree on whether to split
+multi-symbol imports from the same module onto separate lines.  This causes
+`make style` to report a ruff failure even when the file is already correct.
+
+**Use `pre-commit run --all-files` directly** as the authoritative lint/format
+check.  Ruff's isort is the style enforced by CI; `isort --sl` in the
+`Makefile` is a legacy convenience that conflicts with it.
 
 ### pre-commit on NFS home directories
 

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -31,6 +31,7 @@ describe future plans.
 Fixes
 ~~~~~
 
+* Fix ``ModuleNotFoundError: No module named 'hklpy2.misc'``; update imports to ``hklpy2.exceptions`` and ``hklpy2.utils`` for compatibility with hklpy2 ≥ 0.6.0.  :issue:`31`
 * Fix ``forward()`` raising ``AttributeError: no attribute 'set_reals'``; add ``set_reals()`` and ``UB`` setter, change default mode to ``4S+2D mu_chi_phi_fixed``.  :issue:`29`
 * Fix ``calc_UB()`` raising ``SolverError: Lattice must be set``; override ``sample`` setter to push lattice into diffcalc.  :issue:`25`
 * Fix ``wh()`` raising ``SolverError: UB matrix has not been set`` before reflections are added.  :issue:`24`

--- a/src/hklpy2_solvers/diffcalc_solver.py
+++ b/src/hklpy2_solvers/diffcalc_solver.py
@@ -23,7 +23,7 @@ from diffcalc.ub.calc import UBCalculation
 from diffcalc.util import DiffcalcException
 from hklpy2.backends.base import SolverBase
 from hklpy2.backends.typing import ReflectionDict
-from hklpy2.misc import SolverError
+from hklpy2.exceptions import SolverError
 from hklpy2.typing import Matrix3x3, NamedFloatDict
 
 logger = logging.getLogger(__name__)
@@ -385,7 +385,7 @@ class DiffcalcSolver(SolverBase):
 
     @mode.setter
     def mode(self, value: str) -> None:
-        from hklpy2.misc import check_value_in_list
+        from hklpy2.utils import check_value_in_list
 
         check_value_in_list("Mode", value, self.modes, blank_ok=True)
         self._mode = value


### PR DESCRIPTION
- closes #31

## Summary

- Replace `from hklpy2.misc import SolverError` with `from hklpy2.exceptions import SolverError` (module-level import).
- Replace `from hklpy2.misc import check_value_in_list` with `from hklpy2.utils import check_value_in_list` (lazy import inside `mode.setter`).
- Document the `make style` vs `pre-commit run --all-files` conflict in `AGENTS.md` and correct the test path.

`hklpy2` 0.6.0 removed `hklpy2.misc`; both symbols moved to their current locations. All 63 tests pass locally.

Agent: OpenCode (claudesonnet46)