### PR TITLE
Add HOWTO: benchmark a solver geometry; reorganize docs into Guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,10 @@ PRs opened or modified by automated agents must follow the "Agent pytest style" 
 - Include clear commit messages and PR descriptions.
 - If uncertain about design, open an issue instead of making large changes.
 - Respect branch protection: push to feature branches and create PRs.
+- **Never commit unless the user explicitly says to commit.**  Completing
+  a code change does not imply permission to commit it.  Wait for an
+  explicit instruction such as "commit", "commit and push", or
+  "finish the workflow".
 
 ## Test style
 
@@ -263,6 +267,19 @@ question in code maintenance: *Why is this change being made?*
   task that motivates the work.
 - Do not begin coding without a corresponding issue (the only exception is a
   truly trivial fix that needs no explanation).
+
+### Direct commits to `main`
+
+Direct commits to `main` (without a PR) are reserved for low-level
+housekeeping that does not warrant its own issue and branch.  Examples:
+
+- Stamping a release date in ``RELEASE_NOTES.rst`` (``maint vX.Y.Z stamp...``)
+- Fixing a single-word typo in documentation
+- Updating a badge or URL that has changed
+
+Everything else — new features, bug fixes, enhancements, non-trivial
+documentation additions, refactors — must follow the full
+Issue → Branch → Commits → PR workflow.
 
 ### Branches
 

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -32,6 +32,7 @@ describe future plans.
     Enhancements
     ~~~~~~~~~~~~
 
+    * Add HOWTO: benchmark a solver geometry; include downloadable configuration files for each supported geometry.  :issue:`35`
     * Guard ``_apply_mode_constraints()`` to skip rebuilding diffcalc objects when the mode is unchanged, reducing ``forward()`` overhead by ~9%.  :issue:`33`
 
     Maintenance

--- a/docs/source/_static/diffcalc_4s_2d.yml
+++ b/docs/source/_static/diffcalc_4s_2d.yml
@@ -1,0 +1,193 @@
+#hklpy2 configuration file
+
+_header:
+  datetime: '2026-04-17 11:43:42.774008'
+  hklpy2_version: 0.6.1.dev1+g12c49379e
+  python_class: Hklpy2Diffractometer
+  file: diffcalc_4S_2D.yml
+  comment: benchmark configuration
+name: psic
+axes:
+  pseudo_axes:
+  - h
+  - k
+  - l
+  real_axes:
+  - mu
+  - delta
+  - nu
+  - eta
+  - chi
+  - phi
+  axes_xref:
+    h: h
+    k: k
+    l: l
+    mu: mu
+    delta: delta
+    nu: nu
+    eta: eta
+    chi: chi
+    phi: phi
+  extra_axes: {}
+  auxiliary_axes: []
+digits: 4
+sample_name: vibranium
+samples:
+  sample:
+    name: sample
+    lattice:
+      a: 1
+      b: 1
+      c: 1
+      alpha: 90.0
+      beta: 90.0
+      gamma: 90.0
+      digits: 4
+      angle_units: degrees
+      length_units: angstrom
+    reflections: {}
+    reflections_order: []
+    U: &id001
+    - - 1
+      - 0
+      - 0
+    - - 0
+      - 1
+      - 0
+    - - 0
+      - 0
+      - 1
+    UB:
+    - - 6.283185307179586
+      - 0.0
+      - 0.0
+    - - 0.0
+      - 6.283185307179586
+      - 0.0
+    - - 0.0
+      - 0.0
+      - 6.283185307179586
+    digits: 4
+  vibranium:
+    name: vibranium
+    lattice:
+      a: 6.283185307179586
+      b: 6.283185307179586
+      c: 6.283185307179586
+      alpha: 90.0
+      beta: 90.0
+      gamma: 90.0
+      digits: 5
+      angle_units: degrees
+      length_units: angstrom
+    reflections:
+      r400:
+        name: r400
+        geometry: diffcalc_4S_2D
+        pseudos:
+          h: 4
+          k: 0
+          l: 0
+        reals:
+          mu: 0
+          delta: 58.71
+          nu: 0
+          eta: 29.354
+          chi: 0
+          phi: 2
+        reals_units: angstrom
+        wavelength: 1.54
+        wavelength_units: angstrom
+        digits: 4
+      r040:
+        name: r040
+        geometry: diffcalc_4S_2D
+        pseudos:
+          h: 0
+          k: 4
+          l: 0
+        reals:
+          mu: 0
+          delta: 58.71
+          nu: 0
+          eta: 29.354
+          chi: 0
+          phi: 92
+        reals_units: angstrom
+        wavelength: 1.54
+        wavelength_units: angstrom
+        digits: 4
+    reflections_order:
+    - r400
+    - r040
+    U: *id001
+    UB:
+    - - 0.9993914359780045
+      - -0.03488205403674098
+      - -1.5857849061771973e-16
+    - - 0.03488205403674082
+      - 0.9993914359780045
+      - -6.680453827465974e-17
+    - - 0.0
+      - 0.0
+      - 1.0
+    digits: 5
+constraints:
+  mu:
+    label: mu
+    low_limit: -180.0
+    high_limit: 180.0
+    cut_point: -180.0
+    class: LimitsConstraint
+  delta:
+    label: delta
+    low_limit: -180.0
+    high_limit: 180.0
+    cut_point: -180.0
+    class: LimitsConstraint
+  nu:
+    label: nu
+    low_limit: -180.0
+    high_limit: 180.0
+    cut_point: -180.0
+    class: LimitsConstraint
+  eta:
+    label: eta
+    low_limit: -180.0
+    high_limit: 180.0
+    cut_point: -180.0
+    class: LimitsConstraint
+  chi:
+    label: chi
+    low_limit: -180.0
+    high_limit: 180.0
+    cut_point: -180.0
+    class: LimitsConstraint
+  phi:
+    label: phi
+    low_limit: -180.0
+    high_limit: 180.0
+    cut_point: -180.0
+    class: LimitsConstraint
+solver:
+  name: diffcalc
+  description: DiffcalcSolver(name='diffcalc', version='0.1.0', geometry='diffcalc_4S_2D')
+  geometry: diffcalc_4S_2D
+  real_axes:
+  - mu
+  - delta
+  - nu
+  - eta
+  - chi
+  - phi
+  version: 0.1.0
+beam:
+  class: WavelengthXray
+  source_type: Synchrotron X-ray Source
+  energy: 8.050921976530415
+  wavelength: 1.54
+  energy_units: keV
+  wavelength_units: angstrom
+presets:
+  4S+2D mu_chi_phi_fixed: {}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -96,8 +96,9 @@ def setup(app):
 # -- Intersphinx -------------------------------------------------------------
 
 intersphinx_mapping = {
-    "python": ("https://docs.python.org/3", None),
+    "hklpy2": ("https://blueskyproject.io/hklpy2/", None),
     "numpy": ("https://numpy.org/doc/stable", None),
+    "python": ("https://docs.python.org/3", None),
 }
 
 # -- extlinks ----------------------------------------------------------------

--- a/docs/source/guides.rst
+++ b/docs/source/guides.rst
@@ -1,0 +1,36 @@
+.. _guides:
+
+======
+Guides
+======
+
+Step-by-step guides for common tasks with **hklpy2-solvers**.
+Each guide assumes you have already :ref:`installed <install>` the package.
+
+.. toctree::
+   :hidden:
+
+   install
+   usage
+   geometries
+   howto_benchmark
+
+.. grid:: 2
+
+   .. grid-item-card:: :ref:`install`
+
+      Install hklpy2-solvers and make its solvers available to hklpy2.
+
+   .. grid-item-card:: :ref:`usage`
+
+      Create a diffractometer, orient a sample, and compute reciprocal-space
+      positions using hklpy2.
+
+   .. grid-item-card:: :ref:`geometries`
+
+      Supported geometries, operating modes, and axis descriptions for each
+      solver.
+
+   .. grid-item-card:: :ref:`howto_benchmark`
+
+      Measure forward() and inverse() throughput for a solver geometry.

--- a/docs/source/howto_benchmark.rst
+++ b/docs/source/howto_benchmark.rst
@@ -5,8 +5,12 @@ How to benchmark a solver geometry
 =====================================
 
 This guide shows how to measure the computational throughput of a solver
-geometry — how many ``forward()`` and ``inverse()`` operations it can perform
-per second — using the ``hklpy2.utils.benchmark`` function.
+geometry — how many
+:meth:`~hklpy2.diffract.DiffractometerBase.forward` and
+:meth:`~hklpy2.diffract.DiffractometerBase.inverse` operations it can
+perform per second — using
+`hklpy2.utils.benchmark
+<https://blueskyproject.io/hklpy2/autoapi/hklpy2/utils/index.html#hklpy2.utils.benchmark>`__.
 
 Benchmarking is useful when:
 
@@ -31,9 +35,10 @@ You will need ``hklpy2`` ≥ 0.6.0 and ``hklpy2-solvers`` installed:
 Starting from a saved configuration
 -------------------------------------
 
-The easiest way to benchmark is to restore a diffractometer from a saved
-configuration file.  Ready-to-use configurations are provided for each
-supported geometry:
+The easiest way to benchmark is to restore a simulator from a saved
+configuration file using
+:func:`~hklpy2.run_utils.simulator_from_config`.
+Ready-to-use configurations are provided for each supported geometry:
 
 .. list-table::
    :header-rows: 1
@@ -47,14 +52,14 @@ supported geometry:
      - :download:`diffcalc_4s_2d.yml <_static/diffcalc_4s_2d.yml>`
 
 Download the file for your geometry, save it alongside your script, then
-restore the diffractometer and run the benchmark:
+run:
 
 .. code-block:: python
 
    import hklpy2
 
-   diffractometer = hklpy2.simulator_from_config("diffcalc_4s_2d.yml")
-   hklpy2.utils.benchmark(diffractometer)
+   sim = hklpy2.simulator_from_config("diffcalc_4s_2d.yml")
+   hklpy2.utils.benchmark(sim)
 
 Example output::
 
@@ -79,39 +84,73 @@ target for this operation.
 .. note::
 
    Some solvers perform iterative constraint solving and return multiple
-   candidate solutions per ``forward()`` call.  This can result in a
-   ``FAIL`` for ``forward()`` that reflects an upstream library limitation
-   rather than a problem with the solver adapter itself.  See the
+   candidate solutions per
+   :meth:`~hklpy2.diffract.DiffractometerBase.forward` call.  This can
+   result in a ``FAIL`` that reflects an upstream library limitation rather
+   than a problem with the solver itself.  See the
    :ref:`geometries` page for solver-specific notes.
+
+Benchmarking a live diffractometer
+------------------------------------
+
+.. caution::
+
+   `hklpy2.utils.benchmark
+   <https://blueskyproject.io/hklpy2/autoapi/hklpy2/utils/index.html#hklpy2.utils.benchmark>`__
+   runs timing loops directly on the diffractometer object passed to it.
+   Until `bluesky/hklpy2#369 <https://github.com/bluesky/hklpy2/issues/369>`_
+   is resolved, pass a **simulator** restored from a snapshot of your live
+   diffractometer's configuration, rather than the live instrument itself.
+   This guarantees no side effects on motor positions or solver state:
+
+   .. code-block:: python
+
+      import hklpy2
+
+      # Snapshot the live diffractometer, then benchmark the copy.
+      sim = hklpy2.simulator_from_config(my_diffractometer.configuration)
+      hklpy2.utils.benchmark(sim)
+
+   This page will be updated once the fix is released in hklpy2.
 
 Saving your own configuration
 ------------------------------
 
-You can benchmark any diffractometer you have set up by exporting its
-current state to a file with :meth:`export`:
+You can benchmark a diffractometer you have already set up in two ways.
+
+**From a file** — export the current state using
+:meth:`~hklpy2.diffract.DiffractometerBase.export`, then create a new
+simulator and benchmark:
 
 .. code-block:: python
 
-   diffractometer.export("my_config.yml", "benchmark configuration")
+   my_diffractometer.export("my_config.yml", "benchmark configuration")
 
-Then restore and benchmark it later:
+   sim = hklpy2.simulator_from_config("my_config.yml")
+   hklpy2.utils.benchmark(sim)
+
+**Without a file** — pass the
+:attr:`~hklpy2.diffract.DiffractometerBase.configuration` property
+directly, bypassing the file entirely:
 
 .. code-block:: python
 
    import hklpy2
 
-   diffractometer = hklpy2.simulator_from_config("my_config.yml")
-   hklpy2.utils.benchmark(diffractometer)
+   sim = hklpy2.simulator_from_config(my_diffractometer.configuration)
+   hklpy2.utils.benchmark(sim)
 
 Adjusting the number of calls
 -------------------------------
 
-By default ``benchmark`` uses 500 calls per operation.  Pass ``n`` to
-change this — more calls give a more stable measurement:
+By default, `hklpy2.utils.benchmark
+<https://blueskyproject.io/hklpy2/autoapi/hklpy2/utils/index.html#hklpy2.utils.benchmark>`__
+uses 500 calls per operation.  Pass ``n`` to change this — more calls
+give a more stable measurement:
 
 .. code-block:: python
 
-   hklpy2.utils.benchmark(diffractometer, n=2000)
+   hklpy2.utils.benchmark(sim, n=2000)
 
 Capturing results programmatically
 ------------------------------------
@@ -121,7 +160,7 @@ as a dict instead:
 
 .. code-block:: python
 
-   results = hklpy2.utils.benchmark(diffractometer, print=False)
+   results = hklpy2.utils.benchmark(sim, print=False)
    print(results["forward_ops_per_sec"])
    print(results["inverse_ops_per_sec"])
 
@@ -144,12 +183,12 @@ The dict contains:
    * - ``n``
      - Number of calls measured
    * - ``forward_ops_per_sec``
-     - ``forward()`` throughput (ops/sec)
+     - :meth:`~hklpy2.diffract.DiffractometerBase.forward` throughput (ops/sec)
    * - ``forward_ms_per_call``
-     - ``forward()`` latency (ms/call)
+     - :meth:`~hklpy2.diffract.DiffractometerBase.forward` latency (ms/call)
    * - ``inverse_ops_per_sec``
-     - ``inverse()`` throughput (ops/sec)
+     - :meth:`~hklpy2.diffract.DiffractometerBase.inverse` throughput (ops/sec)
    * - ``inverse_ms_per_call``
-     - ``inverse()`` latency (ms/call)
+     - :meth:`~hklpy2.diffract.DiffractometerBase.inverse` latency (ms/call)
    * - ``target_ops_per_sec``
      - Minimum target (2,000 ops/sec)

--- a/docs/source/howto_benchmark.rst
+++ b/docs/source/howto_benchmark.rst
@@ -1,0 +1,155 @@
+.. _howto_benchmark:
+
+=====================================
+How to benchmark a solver geometry
+=====================================
+
+This guide shows how to measure the computational throughput of a solver
+geometry — how many ``forward()`` and ``inverse()`` operations it can perform
+per second — using the ``hklpy2.utils.benchmark`` function.
+
+Benchmarking is useful when:
+
+- evaluating whether a solver is fast enough for a scanning application,
+- comparing two solvers for the same geometry, or
+- detecting a performance regression after a code change.
+
+.. note::
+
+   The benchmark is **purely computational**.  It does not move any motors or
+   communicate with hardware, so it is safe to run on a live diffractometer.
+
+Prerequisites
+-------------
+
+You will need ``hklpy2`` ≥ 0.6.0 and ``hklpy2-solvers`` installed:
+
+.. code-block:: bash
+
+   pip install "hklpy2>=0.6.0" hklpy2-solvers
+
+Starting from a saved configuration
+-------------------------------------
+
+The easiest way to benchmark is to restore a diffractometer from a saved
+configuration file.  Ready-to-use configurations are provided for each
+supported geometry:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 30 50
+
+   * - Solver
+     - Geometry
+     - Configuration file
+   * - ``diffcalc``
+     - :ref:`diffcalc_4S_2D <geometry.diffcalc_4S_2D>`
+     - :download:`diffcalc_4s_2d.yml <_static/diffcalc_4s_2d.yml>`
+
+Download the file for your geometry, save it alongside your script, then
+restore the diffractometer and run the benchmark:
+
+.. code-block:: python
+
+   import hklpy2
+
+   diffractometer = hklpy2.simulator_from_config("diffcalc_4s_2d.yml")
+   hklpy2.utils.benchmark(diffractometer)
+
+Example output::
+
+   Diffractometer benchmark
+     solver:     diffcalc
+     geometry:   diffcalc_4S_2D
+     mode:       4S+2D mu_chi_phi_fixed
+     wavelength: 1.54
+     calls:      500
+
+     operation       ops/sec     ms/call status
+     ------------ ---------- ----------- ------
+     forward()           800       1.250   FAIL
+     inverse()          7300       0.137   PASS
+
+     target: 2,000 ops/sec (+/-10%)
+
+The ``status`` column compares each operation against a target of
+2,000 ops/sec (±10%).  A ``FAIL`` result means the solver is below that
+target for this operation.
+
+.. note::
+
+   Some solvers perform iterative constraint solving and return multiple
+   candidate solutions per ``forward()`` call.  This can result in a
+   ``FAIL`` for ``forward()`` that reflects an upstream library limitation
+   rather than a problem with the solver adapter itself.  See the
+   :ref:`geometries` page for solver-specific notes.
+
+Saving your own configuration
+------------------------------
+
+You can benchmark any diffractometer you have set up by exporting its
+current state to a file with :meth:`export`:
+
+.. code-block:: python
+
+   diffractometer.export("my_config.yml", "benchmark configuration")
+
+Then restore and benchmark it later:
+
+.. code-block:: python
+
+   import hklpy2
+
+   diffractometer = hklpy2.simulator_from_config("my_config.yml")
+   hklpy2.utils.benchmark(diffractometer)
+
+Adjusting the number of calls
+-------------------------------
+
+By default ``benchmark`` uses 500 calls per operation.  Pass ``n`` to
+change this — more calls give a more stable measurement:
+
+.. code-block:: python
+
+   hklpy2.utils.benchmark(diffractometer, n=2000)
+
+Capturing results programmatically
+------------------------------------
+
+Pass ``print=False`` to suppress the printed report and receive the results
+as a dict instead:
+
+.. code-block:: python
+
+   results = hklpy2.utils.benchmark(diffractometer, print=False)
+   print(results["forward_ops_per_sec"])
+   print(results["inverse_ops_per_sec"])
+
+The dict contains:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Key
+     - Description
+   * - ``solver``
+     - Solver name
+   * - ``geometry``
+     - Geometry name
+   * - ``mode``
+     - Current operating mode
+   * - ``wavelength``
+     - Current wavelength (Å)
+   * - ``n``
+     - Number of calls measured
+   * - ``forward_ops_per_sec``
+     - ``forward()`` throughput (ops/sec)
+   * - ``forward_ms_per_call``
+     - ``forward()`` latency (ms/call)
+   * - ``inverse_ops_per_sec``
+     - ``inverse()`` throughput (ops/sec)
+   * - ``inverse_ms_per_call``
+     - ``inverse()`` latency (ms/call)
+   * - ``target_ops_per_sec``
+     - Minimum target (2,000 ops/sec)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -14,6 +14,7 @@ framework via its entry-point interface.
    install
    usage
    geometries
+   howto_benchmark
    api
    release_notes
 
@@ -31,6 +32,10 @@ framework via its entry-point interface.
    .. grid-item-card:: :ref:`geometries`
 
       Supported solver geometries and operating modes.
+
+   .. grid-item-card:: :ref:`howto_benchmark`
+
+      How to benchmark a solver geometry's forward/inverse throughput.
 
    .. grid-item-card:: API Reference
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -4,17 +4,14 @@
 hklpy2-solvers
 ==============
 
-**hklpy2-solvers** provides solver adapters that plug into the
+**hklpy2-solvers** provides solvers that plug into the
 `hklpy2 <https://blueskyproject.io/hklpy2/>`_ diffractometer control
 framework via its entry-point interface.
 
 .. toctree::
    :hidden:
 
-   install
-   usage
-   geometries
-   howto_benchmark
+   guides
    api
    release_notes
 

--- a/src/hklpy2_solvers/diffcalc_solver.py
+++ b/src/hklpy2_solvers/diffcalc_solver.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026 Pete Jemian <prjemian+hklpy2@gmail.com>
 # SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
-Solver adapter wrapping *diffcalc-core* for hklpy2.
+Solver wrapping *diffcalc-core* for hklpy2.
 
 Provides the :class:`DiffcalcSolver` class, which implements the
 :class:`hklpy2.backends.base.SolverBase` interface on top of the
@@ -88,7 +88,7 @@ _MODES: dict[str, dict[str, Any]] = {
 
 class DiffcalcSolver(SolverBase):
     """
-    Solver adapter for diffcalc-core (You 1999, 4S+2D six-circle geometry).
+    Solver for diffcalc-core (You 1999, 4S+2D six-circle geometry).
 
     Wraps :class:`diffcalc.hkl.calc.HklCalculation` behind the
     :class:`~hklpy2.backends.base.SolverBase` interface so that hklpy2


### PR DESCRIPTION
- closes #35

## Summary

- Add `docs/source/howto_benchmark.rst`: geometry-agnostic guide for benchmarking solver throughput using `hklpy2.utils.benchmark`; download table expands as new solvers/geometries are added.
- Add `docs/source/guides.rst`: Diátaxis how-to hub consolidating install, usage, geometries, and benchmark under a single "Guides" navbar entry.
- Add `docs/source/_static/diffcalc_4s_2d.yml`: downloadable benchmark configuration (moved from repo root, lowercased).
- Add hklpy2 intersphinx mapping to `conf.py` for linked references to `forward()`, `inverse()`, `simulator_from_config()`, `export()`, `configuration`.
- Replace "solver adapter" with "solver" throughout docs and source to match hklpy2 glossary nomenclature.
- Add explicit "never commit without instruction" and "direct commits to main" policy rules to `AGENTS.md`.
- Post `bluesky/hklpy2#369` requesting `benchmark()` use a simulator snapshot to avoid live diffractometer side effects; caution note added to HOWTO.

Agent: OpenCode (claudesonnet46)