### PR TITLE
Fix _summary_dict to report correct writable axes per mode

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -29,6 +29,11 @@ describe future plans.
 
     Expected release: tba
 
+    Fixes
+    ~~~~~
+
+    * ``_summary_dict`` reports correct writable axes per mode.  :issue:`37`
+
 0.1.9
 ######
 

--- a/src/hklpy2_solvers/diffcalc_solver.py
+++ b/src/hklpy2_solvers/diffcalc_solver.py
@@ -24,7 +24,7 @@ from diffcalc.util import DiffcalcException
 from hklpy2.backends.base import SolverBase
 from hklpy2.backends.typing import ReflectionDict
 from hklpy2.exceptions import SolverError
-from hklpy2.typing import Matrix3x3, NamedFloatDict
+from hklpy2.typing import KeyValueMap, Matrix3x3, NamedFloatDict
 
 logger = logging.getLogger(__name__)
 
@@ -273,6 +273,31 @@ class DiffcalcSolver(SolverBase):
         This geometry has no extra parameters; always returns ``{}``.
         """
         return {}
+
+    @property
+    def _summary_dict(self) -> KeyValueMap:
+        """Return a summary of the geometry (modes, axes).
+
+        Overrides :attr:`SolverBase._summary_dict` so that each mode
+        reports only the axes actually computed by :meth:`forward`
+        (via :attr:`axes_w`) rather than listing every real axis as
+        writable.
+        """
+        description: dict[str, Any] = {
+            "name": self.geometry,
+            "pseudos": self.pseudo_axis_names,
+            "reals": self.real_axis_names,
+            "modes": {},
+        }
+        original_mode = self.mode
+        for mode in self.modes:
+            self.mode = mode
+            description["modes"][mode] = {
+                "extras": [],
+                "reals": self.axes_w,
+            }
+        self.mode = original_mode
+        return description
 
     def forward(self, pseudos: NamedFloatDict) -> list[NamedFloatDict]:
         """Compute motor positions from pseudo-axis values (hkl -> angles)."""

--- a/tests/test_diffcalc_solver.py
+++ b/tests/test_diffcalc_solver.py
@@ -8,7 +8,7 @@ from contextlib import nullcontext as does_not_raise
 
 import pytest
 
-from hklpy2_solvers.diffcalc_solver import GEOMETRY_NAME, PSEUDO_AXES, REAL_AXES, DiffcalcSolver
+from hklpy2_solvers.diffcalc_solver import _MODES, GEOMETRY_NAME, PSEUDO_AXES, REAL_AXES, DiffcalcSolver
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -1035,3 +1035,116 @@ def test_forward_after_ub_restore(parms, context):
     with context:
         solutions = solver.forward(parms["pseudos"])
         assert len(solutions) >= 1
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        # -- 1 det + 1 ref + 1 samp (a_eq_b is non-motor) --
+        pytest.param(
+            dict(
+                mode="4S+2D mu_fixed a_eq_b delta_fixed",
+                expected_reals=["nu", "eta", "chi", "phi"],
+            ),
+            does_not_raise(),
+            id="a_eq_b non-motor: only mu,delta fixed",
+        ),
+        # -- 1 det + 1 ref + 1 samp (psi is non-motor) --
+        pytest.param(
+            dict(
+                mode="4S+2D phi_fixed psi_fixed nu_fixed",
+                expected_reals=["mu", "delta", "eta", "chi"],
+            ),
+            does_not_raise(),
+            id="psi non-motor: only nu,phi fixed",
+        ),
+        # -- 1 det + 2 samp --
+        pytest.param(
+            dict(
+                mode="4S+2D chi_phi_fixed delta_fixed",
+                expected_reals=["mu", "nu", "eta"],
+            ),
+            does_not_raise(),
+            id="3 motor constraints: delta,chi,phi fixed",
+        ),
+        # -- 1 det + 2 samp (bisect is non-motor) --
+        pytest.param(
+            dict(
+                mode="4S+2D bisect_mu_fixed delta_fixed",
+                expected_reals=["nu", "eta", "chi", "phi"],
+            ),
+            does_not_raise(),
+            id="bisect non-motor: only mu,delta fixed",
+        ),
+        # -- 1 det + 2 samp (bisect+omega are non-motor) --
+        pytest.param(
+            dict(
+                mode="4S+2D bisect_omega_fixed nu_fixed",
+                expected_reals=["mu", "delta", "eta", "chi", "phi"],
+            ),
+            does_not_raise(),
+            id="bisect+omega non-motor: only nu fixed",
+        ),
+        # -- 1 ref + 2 samp --
+        pytest.param(
+            dict(
+                mode="4S+2D chi_mu_fixed a_eq_b",
+                expected_reals=["delta", "nu", "eta", "phi"],
+            ),
+            does_not_raise(),
+            id="1ref+2samp: mu,chi fixed",
+        ),
+        # -- 3 samp --
+        pytest.param(
+            dict(
+                mode="4S+2D eta_chi_phi_fixed",
+                expected_reals=["mu", "delta", "nu"],
+            ),
+            does_not_raise(),
+            id="3samp: eta,chi,phi fixed",
+        ),
+        pytest.param(
+            dict(
+                mode="4S+2D mu_eta_chi_fixed",
+                expected_reals=["delta", "nu", "phi"],
+            ),
+            does_not_raise(),
+            id="3samp: mu,eta,chi fixed",
+        ),
+    ],
+)
+def test_summary_dict(parms, context):
+    """_summary_dict reports correct writable axes per mode (issue #37)."""
+    solver = DiffcalcSolver()
+    with context:
+        sdict = solver._summary_dict
+        mode_entry = sdict["modes"][parms["mode"]]
+        assert mode_entry["reals"] == parms["expected_reals"]
+        assert mode_entry["extras"] == []
+        # Top-level keys are correct regardless of mode.
+        assert sdict["name"] == GEOMETRY_NAME
+        assert sdict["pseudos"] == list(PSEUDO_AXES)
+        assert sdict["reals"] == list(REAL_AXES)
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(),
+            does_not_raise(),
+            id="all modes writable axes match axes_w",
+        ),
+    ],
+)
+def test_summary_dict_all_modes(parms, context):
+    """Every mode in _summary_dict has reals == axes_w (issue #37)."""
+    solver = DiffcalcSolver()
+    with context:
+        sdict = solver._summary_dict
+        assert set(sdict["modes"].keys()) == set(_MODES.keys())
+        for mode_name in _MODES:
+            solver.mode = mode_name
+            expected = solver.axes_w
+            actual = sdict["modes"][mode_name]["reals"]
+            assert actual == expected, f"Mode {mode_name!r}: expected writable {expected}, got {actual}"


### PR DESCRIPTION
## Summary

- closes #37
- Override `_summary_dict` in `DiffcalcSolver` so that each mode reports only the axes actually computed by `forward()` (via `axes_w`) instead of listing all six real axes as writable.
- Add `test_summary_dict` (8 parametrized cases covering all four mode categories, including non-motor constraints like `a_eq_b`, `bisect`, `omega`, `psi`) and `test_summary_dict_all_modes` (exhaustive check across all 23 modes).
- Coverage unchanged at 94% (new method fully covered, no new uncovered lines).

Agent: OpenCode (claudeopus46)