### PR TITLE
Docs: add ad_hoc geometries, per-solver guides, change default diffcalc mode

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -29,6 +29,13 @@ describe future plans.
 
     Expected release: tba
 
+    Enhancements
+    ~~~~~~~~~~~~
+
+    * Add all ``ad_hoc`` solver geometries (10 geometries, modes, and axes) to ``geometries.rst``; add ``ad_hoc`` solver to the "Available solvers" table in ``usage.rst``.  :issue:`40`
+    * Add per-solver how-to guides (``guide_diffcalc.rst``, ``guide_ad_hoc.rst``) following the Diataxis framework.  :issue:`40`
+    * Change ``diffcalc`` default mode from ``4S+2D mu_chi_phi_fixed`` to ``4S+2D bisect_eta_fixed nu_fixed`` (vertical bisector).  :issue:`40`
+
 0.2.0
 ######
 

--- a/docs/source/geometries.rst
+++ b/docs/source/geometries.rst
@@ -8,15 +8,24 @@ Each solver registered under the ``hklpy2.solver`` entry-point group
 exposes one or more named geometries.  The geometry name is passed to
 the solver when it is instantiated by hklpy2.
 
+.. contents:: On this page
+   :local:
+   :depth: 2
+
 .. _geometry.diffcalc_4S_2D:
 
-diffcalc solver
----------------
+``diffcalc`` solver
+-------------------
 
 :class:`~hklpy2_solvers.diffcalc_solver.DiffcalcSolver`
 
 Wraps `diffcalc-core <https://github.com/DiamondLightSource/diffcalc-core>`_
 (You 1999).
+
+diffcalc_4S_2D
+~~~~~~~~~~~~~~
+
+H. You, *J. Appl. Cryst.* **32**, 614 (1999) six-circle geometry.
 
 .. list-table:: ``diffcalc_4S_2D`` geometry
    :header-rows: 1
@@ -30,11 +39,11 @@ Wraps `diffcalc-core <https://github.com/DiamondLightSource/diffcalc-core>`_
      - ``mu``, ``delta``, ``nu``, ``eta``, ``chi``, ``phi``
    * - Pseudo axes
      - ``h``, ``k``, ``l``
-   * - Reference
-     - H. You, *J. Appl. Cryst.* **32**, 614 (1999)
+   * - Default mode
+     - ``4S+2D bisect_eta_fixed nu_fixed``
 
 Operating modes
-~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^
 
 The diffcalc solver selects three diffractometer constraints to fix for
 each operating mode.  This geometry has no extra parameters
@@ -93,17 +102,17 @@ remaining axes are held constant (``axes_c``, derived by hklpy2).
    * - ``4S+2D mu_eta_phi_fixed``
      - mu=0, eta=0, phi=0
    * - ``4S+2D mu_eta_chi_fixed``
-      - mu=0, eta=0, chi=0
+     - mu=0, eta=0, chi=0
 
 Default mode
-~~~~~~~~~~~~
+^^^^^^^^^^^^
 
-The default mode is ``4S+2D mu_chi_phi_fixed`` (mu=0, chi=0, phi=0).  This is
-a 3-sample mode with no reference-vector constraints, making it robust for the
-widest range of reflections.  It is equivalent to a basic 4-circle geometry
-operating in the vertical scattering plane.
+The default mode is ``4S+2D bisect_eta_fixed nu_fixed`` (bisect,
+eta=0, nu=0).  This is equivalent to ``bisecting_vertical`` in E6C
+terminology: scattering stays in the vertical plane with the sample
+angle bisecting the detector angle (``eta = delta/2``).
 
-.. note:: **Why not a bisector mode?**
+.. note:: **Bisector modes**
 
    Following You (1999) Figure 1 (see also
    `diffcalc-core docs <https://diffcalc-core.readthedocs.io>`_),
@@ -111,15 +120,19 @@ operating in the vertical scattering plane.
    **horizontally**; ``delta`` rotates about the horizontal axis and swings
    the detector **vertically**.
 
-   A ``bissector_vertical`` equivalent (E6C terminology) would require
-   ``bisect=True`` + ``mu=0`` + ``nu=0``, but that combination is not among
-   diffcalc's available modes.  A ``bissector_horizontal`` equivalent would
-   require a ``mu = nu/2`` bisector condition; diffcalc's ``bisect`` constraint
-   implements only ``eta = delta/2`` (vertical bisector), so that is also
-   unavailable.
+   The ``bisect`` constraint implements ``eta = delta/2`` (vertical
+   bisector).  ``4S+2D bisect_eta_fixed nu_fixed`` (bisect + eta=0 +
+   nu=0) is equivalent to a ``bisecting_vertical`` mode: scattering
+   stays in the vertical plane with the sample bisecting the detector
+   angle.  ``4S+2D bisect_mu_fixed delta_fixed`` (bisect + mu=0 +
+   delta=0) is the horizontal counterpart.
+
+   In the mode name the *bisected sample axis* is stated; the
+   corresponding *detector axis* is implied by the bisect constraint
+   (``delta``).
 
 Mode naming convention
-~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^
 
 All mode names follow the pattern ``4S+2D <constraints>``, where ``4S+2D``
 identifies the You (1999) geometry and the suffix encodes the three fixed
@@ -130,12 +143,12 @@ constraints:
 - ``a_eq_b`` — reference-vector constraint: azimuthal reference equals
   scattering vector direction.  **Caution:** singular when the scattering
   vector is parallel to the reference vector; avoid as a default.
-- ``bisect`` — bisector condition: ``eta = delta/2``.  Implements the vertical
-  bisector only; no horizontal bisector equivalent exists in diffcalc.
+- ``bisect`` — bisector condition: ``eta = delta/2``.  The bisected sample
+  axis (e.g. ``eta``) is named; the detector axis (``delta``) is implied.
 - ``psi_fixed``, ``omega_fixed`` — azimuthal or omega angle fixed at zero.
 
 Extensibility
-~~~~~~~~~~~~~
+^^^^^^^^^^^^^
 
 The available constraint names are fixed by diffcalc-core and cannot be
 changed without modifying that library.  Each constraint name has specific
@@ -144,3 +157,460 @@ a handle for the underlying algebra that reduces the degrees of freedom during
 position calculation.  A new constraint (e.g. ``mu = nu/2``) would require
 new code in diffcalc-core, not just a new entry in ``_MODES``.  From the
 user's perspective the mode list is not extensible.
+
+----
+
+.. _geometries.ad_hoc:
+
+``ad_hoc`` solver
+-----------------
+
+:class:`~hklpy2_solvers.ad_hoc_solver.AdHocSolver`
+
+Wraps `ad_hoc_diffractometer <https://github.com/prjemian/ad_hoc_diffractometer>`_
+(Jemian 2026).
+
+The ``ad_hoc`` solver discovers geometries dynamically from the
+`ad_hoc_diffractometer <https://github.com/prjemian/ad_hoc_diffractometer>`_
+library.  All geometries registered in the
+library's geometry registry (including via entry points) are
+automatically available.  The pseudo axes are always ``h``, ``k``, ``l``
+and ``extras`` is always ``{}``.
+
+.. _geometry.fourcv:
+
+fourcv
+~~~~~~
+
+Busing & Levy four-circle vertical-scattering geometry.
+
+.. list-table:: ``fourcv`` geometry
+   :header-rows: 1
+   :widths: 20 80
+
+   * - Property
+     - Value
+   * - Geometry name
+     - ``fourcv``
+   * - Real axes
+     - ``omega``, ``chi``, ``phi``, ``ttheta``
+   * - Pseudo axes
+     - ``h``, ``k``, ``l``
+   * - Default mode
+     - ``bisecting``
+
+.. list-table:: ``fourcv`` operating modes
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Mode name
+     - Constant stages
+   * - ``bisecting``
+     - omega
+   * - ``fixed_chi``
+     - chi
+   * - ``fixed_phi``
+     - phi
+   * - ``constant_omega``
+     - omega
+   * - ``psi_constant``
+     - *(none)*
+   * - ``double_diffraction``
+     - *(none)*
+
+.. _geometry.fourch:
+
+fourch
+~~~~~~
+
+Four-circle horizontal-scattering geometry.
+
+.. list-table:: ``fourch`` geometry
+   :header-rows: 1
+   :widths: 20 80
+
+   * - Property
+     - Value
+   * - Geometry name
+     - ``fourch``
+   * - Real axes
+     - ``omega``, ``chi``, ``phi``, ``ttheta``
+   * - Pseudo axes
+     - ``h``, ``k``, ``l``
+   * - Default mode
+     - ``bisecting``
+
+.. list-table:: ``fourch`` operating modes
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Mode name
+     - Constant stages
+   * - ``bisecting``
+     - omega
+   * - ``fixed_chi``
+     - chi
+   * - ``fixed_phi``
+     - phi
+   * - ``constant_omega``
+     - omega
+   * - ``psi_constant``
+     - *(none)*
+   * - ``double_diffraction``
+     - *(none)*
+
+.. _geometry.psic:
+
+psic
+~~~~
+
+You (1999) six-circle geometry (psi-circle).
+
+.. list-table:: ``psic`` geometry
+   :header-rows: 1
+   :widths: 20 80
+
+   * - Property
+     - Value
+   * - Geometry name
+     - ``psic``
+   * - Real axes
+     - ``mu``, ``eta``, ``chi``, ``phi``, ``nu``, ``delta``
+   * - Pseudo axes
+     - ``h``, ``k``, ``l``
+   * - Default mode
+     - ``bisecting_vertical``
+
+.. list-table:: ``psic`` operating modes
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Mode name
+     - Constant stages
+   * - ``bisecting_vertical``
+     - eta, mu, nu
+   * - ``fixed_chi``
+     - chi, eta, nu
+   * - ``fixed_phi``
+     - phi, eta, nu
+   * - ``fixed_mu``
+     - mu, eta, nu
+   * - ``bisecting_horizontal``
+     - mu, eta, delta
+   * - ``fixed_nu``
+     - nu, eta, mu
+   * - ``double_diffraction_vertical``
+     - mu, nu
+   * - ``double_diffraction_horizontal``
+     - eta, delta
+   * - ``lifting_detector_mu``
+     - mu, eta
+   * - ``lifting_detector_phi``
+     - phi, mu
+   * - ``psi_constant_vertical``
+     - eta, mu
+   * - ``psi_constant_horizontal``
+     - mu, eta
+
+.. _geometry.sixc:
+
+sixc
+~~~~
+
+Lohmeier & Vlieg (1993) six-circle geometry.
+
+.. list-table:: ``sixc`` geometry
+   :header-rows: 1
+   :widths: 20 80
+
+   * - Property
+     - Value
+   * - Geometry name
+     - ``sixc``
+   * - Real axes
+     - ``alpha``, ``omega``, ``chi``, ``phi``, ``delta``, ``gamma``
+   * - Pseudo axes
+     - ``h``, ``k``, ``l``
+   * - Default mode
+     - ``bisecting_4c``
+
+.. list-table:: ``sixc`` operating modes
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Mode name
+     - Constant stages
+   * - ``bisecting_4c``
+     - alpha, gamma, omega
+   * - ``fixed_gamma_5c``
+     - gamma, alpha, omega
+   * - ``fixed_alpha_5c``
+     - alpha, omega, gamma
+   * - ``fixed_alpha_zaxis``
+     - alpha, chi
+   * - ``fixed_beta_zaxis``
+     - gamma, chi
+   * - ``alpha_eq_beta_zaxis``
+     - chi, phi
+
+.. _geometry.fivec:
+
+fivec
+~~~~~
+
+Five-circle geometry (four-circle with additional mu tilt).
+
+.. list-table:: ``fivec`` geometry
+   :header-rows: 1
+   :widths: 20 80
+
+   * - Property
+     - Value
+   * - Geometry name
+     - ``fivec``
+   * - Real axes
+     - ``mu``, ``omega``, ``chi``, ``phi``, ``ttheta``
+   * - Pseudo axes
+     - ``h``, ``k``, ``l``
+   * - Default mode
+     - ``bisecting_4c``
+
+.. list-table:: ``fivec`` operating modes
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Mode name
+     - Constant stages
+   * - ``bisecting_4c``
+     - mu, omega
+   * - ``fixed_chi``
+     - mu, chi
+   * - ``fixed_phi``
+     - mu, phi
+   * - ``fixed_mu``
+     - mu, omega
+   * - ``constant_omega_noncoplanar``
+     - mu, omega
+
+.. _geometry.kappa4cv:
+
+kappa4cv
+~~~~~~~~
+
+Kappa four-circle vertical-scattering geometry.
+
+.. list-table:: ``kappa4cv`` geometry
+   :header-rows: 1
+   :widths: 20 80
+
+   * - Property
+     - Value
+   * - Geometry name
+     - ``kappa4cv``
+   * - Real axes
+     - ``komega``, ``kappa``, ``kphi``, ``ttheta``
+   * - Pseudo axes
+     - ``h``, ``k``, ``l``
+   * - Default mode
+     - ``bisecting``
+
+.. list-table:: ``kappa4cv`` operating modes
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Mode name
+     - Constant stages
+   * - ``bisecting``
+     - komega
+   * - ``fixed_kphi``
+     - kphi
+   * - ``constant_omega``
+     - omega
+   * - ``constant_chi``
+     - chi
+   * - ``constant_phi``
+     - phi
+   * - ``psi_constant``
+     - *(none)*
+   * - ``double_diffraction``
+     - *(none)*
+
+.. _geometry.kappa4ch:
+
+kappa4ch
+~~~~~~~~
+
+Kappa four-circle horizontal-scattering geometry.
+
+.. list-table:: ``kappa4ch`` geometry
+   :header-rows: 1
+   :widths: 20 80
+
+   * - Property
+     - Value
+   * - Geometry name
+     - ``kappa4ch``
+   * - Real axes
+     - ``komega``, ``kappa``, ``kphi``, ``ttheta``
+   * - Pseudo axes
+     - ``h``, ``k``, ``l``
+   * - Default mode
+     - ``bisecting``
+
+.. list-table:: ``kappa4ch`` operating modes
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Mode name
+     - Constant stages
+   * - ``bisecting``
+     - komega
+   * - ``fixed_kphi``
+     - kphi
+   * - ``constant_omega``
+     - omega
+   * - ``constant_chi``
+     - chi
+   * - ``constant_phi``
+     - phi
+   * - ``psi_constant``
+     - *(none)*
+
+.. _geometry.kappa6c:
+
+kappa6c
+~~~~~~~
+
+Kappa six-circle geometry.
+
+.. list-table:: ``kappa6c`` geometry
+   :header-rows: 1
+   :widths: 20 80
+
+   * - Property
+     - Value
+   * - Geometry name
+     - ``kappa6c``
+   * - Real axes
+     - ``mu``, ``komega``, ``kappa``, ``kphi``, ``nu``, ``delta``
+   * - Pseudo axes
+     - ``h``, ``k``, ``l``
+   * - Default mode
+     - ``bisecting_vertical``
+
+.. list-table:: ``kappa6c`` operating modes
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Mode name
+     - Constant stages
+   * - ``bisecting_vertical``
+     - komega, mu, nu
+   * - ``bisecting_horizontal``
+     - mu, komega, delta
+   * - ``fixed_kphi``
+     - kphi, mu, nu
+   * - ``fixed_mu``
+     - mu, komega, nu
+   * - ``fixed_nu``
+     - nu, komega, mu
+   * - ``fixed_delta``
+     - delta, mu, komega
+   * - ``lifting_detector_mu``
+     - mu, komega
+   * - ``lifting_detector_kphi``
+     - kphi, mu
+   * - ``psi_constant_vertical``
+     - komega, mu
+   * - ``psi_constant_horizontal``
+     - mu, komega
+   * - ``double_diffraction_vertical``
+     - mu, nu
+   * - ``double_diffraction_horizontal``
+     - komega, delta
+
+.. _geometry.zaxis:
+
+zaxis
+~~~~~
+
+Z-axis surface diffraction geometry.
+
+.. list-table:: ``zaxis`` geometry
+   :header-rows: 1
+   :widths: 20 80
+
+   * - Property
+     - Value
+   * - Geometry name
+     - ``zaxis``
+   * - Real axes
+     - ``alpha``, ``Z``, ``delta``, ``gamma``
+   * - Pseudo axes
+     - ``h``, ``k``, ``l``
+   * - Default mode
+     - ``zaxis`` (first available)
+
+.. list-table:: ``zaxis`` operating modes
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Mode name
+     - Constant stages
+   * - ``zaxis``
+     - *(none)*
+   * - ``reflectivity``
+     - *(none)*
+
+.. _geometry.s2d2:
+
+s2d2
+~~~~
+
+Two-sample / two-detector surface diffraction geometry.
+
+.. list-table:: ``s2d2`` geometry
+   :header-rows: 1
+   :widths: 20 80
+
+   * - Property
+     - Value
+   * - Geometry name
+     - ``s2d2``
+   * - Real axes
+     - ``mu``, ``Z``, ``nu``, ``delta``
+   * - Pseudo axes
+     - ``h``, ``k``, ``l``
+   * - Default mode
+     - ``mu_fixed`` (first available)
+
+.. list-table:: ``s2d2`` operating modes
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Mode name
+     - Constant stages
+   * - ``mu_fixed``
+     - mu
+   * - ``reflectivity``
+     - *(none)*
+
+Kappa geometries
+~~~~~~~~~~~~~~~~
+
+The kappa geometries (:ref:`kappa4cv <geometry.kappa4cv>`,
+:ref:`kappa4ch <geometry.kappa4ch>`, :ref:`kappa6c <geometry.kappa6c>`) accept a
+``kappa_alpha_deg`` keyword argument when the solver is created.  This
+sets the fixed tilt angle of the kappa arm.  The default is 50 degrees.
+The kappa modes ``constant_omega``, ``constant_chi``, and
+``constant_phi`` constrain the *equivalent Euler* angles rather than the
+physical kappa motors.
+
+Extensibility
+~~~~~~~~~~~~~
+
+The ``ad_hoc`` solver discovers geometries dynamically from the
+`ad_hoc_diffractometer <https://github.com/prjemian/ad_hoc_diffractometer>`_
+library's registry.  New geometries added to
+the library (including via entry points) are automatically available
+without changes to the solver code.

--- a/docs/source/guide_ad_hoc.rst
+++ b/docs/source/guide_ad_hoc.rst
@@ -1,0 +1,184 @@
+.. _guide_ad_hoc:
+
+==========================================
+How to use the ``ad_hoc`` solver
+==========================================
+
+This guide shows how to create a diffractometer with the ``ad_hoc``
+solver, orient a crystalline sample, and compute reciprocal-space
+positions.  It assumes you have already :ref:`installed <install>` the
+package.
+
+The ``ad_hoc`` solver wraps the
+`ad_hoc_diffractometer <https://github.com/prjemian/ad_hoc_diffractometer>`_
+library and provides 10 diffractometer geometries ranging from
+four-circle to six-circle and kappa configurations.  See
+:ref:`geometries.ad_hoc` for the full list.
+
+Create a diffractometer
+-----------------------
+
+**Four-circle vertical** (the default geometry):
+
+.. code-block:: python
+
+   import hklpy2
+
+   fourc = hklpy2.creator(
+       solver="ad_hoc",
+       geometry="fourcv",
+       name="fourc",
+   )
+
+The object ``fourc`` has four real axes (``omega``, ``chi``, ``phi``,
+``ttheta``) and three pseudo axes (``h``, ``k``, ``l``).
+
+**Six-circle (psic)**:
+
+.. code-block:: python
+
+   psic = hklpy2.creator(
+       solver="ad_hoc",
+       geometry="psic",
+       name="psic",
+   )
+
+**Kappa geometry** (set the kappa tilt angle via ``solver_kwargs``):
+
+.. code-block:: python
+
+   kappa = hklpy2.creator(
+       solver="ad_hoc",
+       geometry="kappa4cv",
+       name="kappa",
+       solver_kwargs={"kappa_alpha_deg": 50},
+   )
+
+Set the crystal lattice
+-----------------------
+
+.. code-block:: python
+
+   fourc.sample.lattice = hklpy2.SI_LATTICE_PARAMETERS
+   fourc.wavelength.set(1.0)
+
+Add orientation reflections
+---------------------------
+
+Provide two reflections measured at known motor positions:
+
+.. code-block:: python
+
+   import math
+
+   theta = math.degrees(math.asin(1.0 / (2 * 5.431)))
+   tth = 2 * theta
+
+   r1 = fourc.sample.add_reflection(
+       pseudos={"h": 1, "k": 0, "l": 0},
+       reals={"omega": theta, "chi": 0, "phi": 0, "ttheta": tth},
+       wavelength=1.0,
+       name="r1",
+   )
+   r2 = fourc.sample.add_reflection(
+       pseudos={"h": 0, "k": 1, "l": 0},
+       reals={"omega": theta, "chi": 0, "phi": 90, "ttheta": tth},
+       wavelength=1.0,
+       name="r2",
+   )
+
+Calculate the UB matrix
+-----------------------
+
+.. code-block:: python
+
+   fourc.core.calc_UB(r1, r2)
+
+Choose an operating mode
+------------------------
+
+The default mode for ``fourcv`` is ``bisecting``.  To change it:
+
+.. code-block:: python
+
+   fourc.solver.mode = "fixed_phi"
+
+See :ref:`geometries.ad_hoc` for the full mode tables for each geometry.
+
+Compute motor positions (forward)
+---------------------------------
+
+.. code-block:: python
+
+   fourc.forward(1, 0, 0)
+
+This returns a list of motor-position solutions for the given ``(h, k, l)``.
+
+Compute (h, k, l) from motor positions (inverse)
+-------------------------------------------------
+
+.. code-block:: python
+
+   fourc.inverse()
+
+This returns the current ``(h, k, l)`` values from the current motor
+positions.
+
+Available geometries at a glance
+---------------------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 40 10 30
+
+   * - Geometry
+     - Real axes
+     - Modes
+     - Default mode
+   * - :ref:`fourcv <geometry.fourcv>`
+     - omega, chi, phi, ttheta
+     - 6
+     - bisecting
+   * - :ref:`fourch <geometry.fourch>`
+     - omega, chi, phi, ttheta
+     - 6
+     - bisecting
+   * - :ref:`psic <geometry.psic>`
+     - mu, eta, chi, phi, nu, delta
+     - 12
+     - bisecting_vertical
+   * - :ref:`sixc <geometry.sixc>`
+     - alpha, omega, chi, phi, delta, gamma
+     - 6
+     - bisecting_4c
+   * - :ref:`fivec <geometry.fivec>`
+     - mu, omega, chi, phi, ttheta
+     - 5
+     - bisecting_4c
+   * - :ref:`kappa4cv <geometry.kappa4cv>`
+     - komega, kappa, kphi, ttheta
+     - 7
+     - bisecting
+   * - :ref:`kappa4ch <geometry.kappa4ch>`
+     - komega, kappa, kphi, ttheta
+     - 6
+     - bisecting
+   * - :ref:`kappa6c <geometry.kappa6c>`
+     - mu, komega, kappa, kphi, nu, delta
+     - 12
+     - bisecting_vertical
+   * - :ref:`zaxis <geometry.zaxis>`
+     - alpha, Z, delta, gamma
+     - 2
+     - zaxis
+   * - :ref:`s2d2 <geometry.s2d2>`
+     - mu, Z, nu, delta
+     - 2
+     - mu_fixed
+
+.. seealso::
+
+   - :ref:`geometries.ad_hoc` — full reference for all geometries and modes
+   - :ref:`howto_benchmark` — measure solver throughput
+   - `hklpy2 user guide <https://blueskyproject.io/hklpy2/>`_ — full
+     hklpy2 documentation

--- a/docs/source/guide_diffcalc.rst
+++ b/docs/source/guide_diffcalc.rst
@@ -1,0 +1,121 @@
+.. _guide_diffcalc:
+
+==========================================
+How to use the ``diffcalc`` solver
+==========================================
+
+This guide shows how to create a diffractometer with the ``diffcalc``
+solver, orient a crystalline sample, and compute reciprocal-space
+positions.  It assumes you have already :ref:`installed <install>` the
+package.
+
+The ``diffcalc`` solver wraps
+`diffcalc-core <https://github.com/DiamondLightSource/diffcalc-core>`_
+(You 1999) and provides a single six-circle geometry,
+:ref:`diffcalc_4S_2D <geometry.diffcalc_4S_2D>`, with 23 operating
+modes.
+
+Create a diffractometer
+-----------------------
+
+.. code-block:: python
+
+   import hklpy2
+
+   psic = hklpy2.creator(
+       solver="diffcalc",
+       geometry="diffcalc_4S_2D",
+       name="psic",
+   )
+
+The object ``psic`` has six real axes (``mu``, ``delta``, ``nu``,
+``eta``, ``chi``, ``phi``) and three pseudo axes (``h``, ``k``, ``l``).
+
+Set the crystal lattice
+-----------------------
+
+.. code-block:: python
+
+   psic.sample.lattice = hklpy2.SI_LATTICE_PARAMETERS
+   psic.wavelength.set(1.54)
+
+Add orientation reflections
+---------------------------
+
+Provide two reflections measured at known motor positions:
+
+.. code-block:: python
+
+   r1 = psic.add_reflection(
+       pseudos={"h": 4, "k": 0, "l": 0},
+       reals={"mu": 0, "delta": 69.0966, "nu": 0, "eta": 34.5483, "chi": 0, "phi": 0},
+       wavelength=1.54,
+       name="r1",
+   )
+   r2 = psic.add_reflection(
+       pseudos={"h": 0, "k": 4, "l": 0},
+       reals={"mu": 0, "delta": 69.0966, "nu": 0, "eta": 34.5483, "chi": 0, "phi": 90},
+       wavelength=1.54,
+       name="r2",
+   )
+
+Calculate the UB matrix
+-----------------------
+
+.. code-block:: python
+
+   psic.core.calc_UB(r1, r2)
+
+Choose an operating mode
+------------------------
+
+The default mode is ``4S+2D bisect_eta_fixed nu_fixed`` (vertical
+bisector: ``eta = delta/2``, eta=0, nu=0).  To change it:
+
+.. code-block:: python
+
+   psic.solver.mode = "4S+2D eta_chi_phi_fixed"
+
+See :ref:`geometry.diffcalc_4S_2D` for the full list of 23 modes.
+
+Compute motor positions (forward)
+---------------------------------
+
+.. code-block:: python
+
+   psic.forward(4, 0, 0)
+
+This returns a list of motor-position solutions for the given ``(h, k, l)``.
+
+Compute (h, k, l) from motor positions (inverse)
+-------------------------------------------------
+
+.. code-block:: python
+
+   psic.inverse()
+
+This returns the current ``(h, k, l)`` values from the current motor
+positions.
+
+Available geometries at a glance
+---------------------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 40 10 30
+
+   * - Geometry
+     - Real axes
+     - Modes
+     - Default mode
+   * - :ref:`diffcalc_4S_2D <geometry.diffcalc_4S_2D>`
+     - mu, delta, nu, eta, chi, phi
+     - 23
+     - 4S+2D bisect_eta_fixed nu_fixed
+
+.. seealso::
+
+   - :ref:`geometry.diffcalc_4S_2D` — full reference for axes and modes
+   - :ref:`howto_benchmark` — measure solver throughput
+   - `hklpy2 user guide <https://blueskyproject.io/hklpy2/>`_ — full
+     hklpy2 documentation

--- a/docs/source/guides.rst
+++ b/docs/source/guides.rst
@@ -12,6 +12,8 @@ Each guide assumes you have already :ref:`installed <install>` the package.
 
    install
    usage
+   guide_diffcalc
+   guide_ad_hoc
    geometries
    howto_benchmark
 
@@ -25,6 +27,16 @@ Each guide assumes you have already :ref:`installed <install>` the package.
 
       Create a diffractometer, orient a sample, and compute reciprocal-space
       positions using hklpy2.
+
+   .. grid-item-card:: :ref:`guide_diffcalc`
+
+      Step-by-step guide to orienting a sample and computing positions
+      with the ``diffcalc`` solver (You 1999 six-circle).
+
+   .. grid-item-card:: :ref:`guide_ad_hoc`
+
+      Step-by-step guide to creating diffractometers with the ``ad_hoc``
+      solver (10 geometries from four-circle to kappa six-circle).
 
    .. grid-item-card:: :ref:`geometries`
 

--- a/docs/source/howto_benchmark.rst
+++ b/docs/source/howto_benchmark.rst
@@ -51,6 +51,12 @@ Ready-to-use configurations are provided for each supported geometry:
      - :ref:`diffcalc_4S_2D <geometry.diffcalc_4S_2D>`
      - :download:`diffcalc_4s_2d.yml <_static/diffcalc_4s_2d.yml>`
 
+.. note::
+
+   Configuration files for ``ad_hoc`` solver geometries are not yet
+   provided.  You can create your own using the :ref:`guide_ad_hoc`
+   workflow and :meth:`~hklpy2.diffract.DiffractometerBase.export`.
+
 Download the file for your geometry, save it alongside your script, then
 run:
 
@@ -66,7 +72,7 @@ Example output::
    Diffractometer benchmark
      solver:     diffcalc
      geometry:   diffcalc_4S_2D
-     mode:       4S+2D mu_chi_phi_fixed
+     mode:       4S+2D bisect_eta_fixed nu_fixed
      wavelength: 1.54
      calls:      500
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -26,6 +26,16 @@ framework via its entry-point interface.
       How to use with hklpy2: load solver, set lattice, add reflections,
       calculate UB, forward and inverse calculations.
 
+   .. grid-item-card:: :ref:`guide_diffcalc`
+
+      Guide: orient a sample and compute positions with the ``diffcalc``
+      solver.
+
+   .. grid-item-card:: :ref:`guide_ad_hoc`
+
+      Guide: create diffractometers with the ``ad_hoc`` solver
+      (10 geometries).
+
    .. grid-item-card:: :ref:`geometries`
 
       Supported solver geometries and operating modes.

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -23,14 +23,26 @@ Available solvers
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 30 50
+   :widths: 15 25 60
 
    * - Solver name
-     - Geometry name
-     - Common name
+     - Geometry name(s)
+     - Description
    * - ``diffcalc``
      - :ref:`diffcalc_4S_2D <geometry.diffcalc_4S_2D>`
-     - *psic* (You 1999 six-circle)
+     - You (1999) six-circle geometry via
+       `diffcalc-core <https://github.com/DiamondLightSource/diffcalc-core>`_.
+       23 operating modes.
+   * - ``ad_hoc``
+     - :ref:`fourcv <geometry.fourcv>`, :ref:`fourch <geometry.fourch>`,
+       :ref:`psic <geometry.psic>`, :ref:`sixc <geometry.sixc>`,
+       :ref:`fivec <geometry.fivec>`,
+       :ref:`kappa4cv <geometry.kappa4cv>`, :ref:`kappa4ch <geometry.kappa4ch>`,
+       :ref:`kappa6c <geometry.kappa6c>`,
+       :ref:`zaxis <geometry.zaxis>`, :ref:`s2d2 <geometry.s2d2>`
+     - 10 diffractometer geometries via
+       `ad_hoc_diffractometer <https://github.com/prjemian/ad_hoc_diffractometer>`_.
+       2--12 modes per geometry.
 
 See :ref:`geometries` for the full description of each geometry and its
 operating modes.
@@ -46,16 +58,27 @@ select the backend:
 
    import hklpy2
 
+   # Using the diffcalc solver (You 1999 six-circle)
    psic = hklpy2.creator(
        solver="diffcalc",
        geometry="diffcalc_4S_2D",
        name="psic",
    )
 
-The object ``psic`` is a fully-functional ``hklpy2`` diffractometer with
-simulated motor positioners for all six real axes
-(``mu``, ``delta``, ``nu``, ``eta``, ``chi``, ``phi``) and the three
+   # Using the ad_hoc solver (Busing & Levy four-circle vertical)
+   fourc = hklpy2.creator(
+       solver="ad_hoc",
+       geometry="fourcv",
+       name="fourc",
+   )
+
+The resulting objects are fully-functional ``hklpy2`` diffractometers with
+simulated motor positioners for all real axes and the three
 reciprocal-space pseudo axes (``h``, ``k``, ``l``).
+
+See :ref:`guide_diffcalc` and :ref:`guide_ad_hoc` for step-by-step
+instructions on orienting a sample and computing positions with each
+solver.
 
 Further use
 -----------

--- a/src/hklpy2_solvers/diffcalc_solver.py
+++ b/src/hklpy2_solvers/diffcalc_solver.py
@@ -127,11 +127,11 @@ class DiffcalcSolver(SolverBase):
         super().__init__(geometry, **kwargs)
 
         # Apply default mode if none was set via kwargs.
-        # Use mu_chi_phi_fixed: a 3-sample mode with no reference-vector
-        # constraints, robust for most reflections.  See geometries.rst for
-        # why bisector modes are not suitable as a default.
+        # Use bisect_eta_fixed nu_fixed: vertical bisector mode
+        # (eta = delta/2, eta=0, nu=0).  Equivalent to bisecting_vertical
+        # in E6C terminology.  See geometries.rst for details.
         if not self.mode and self.modes:
-            self.mode = "4S+2D mu_chi_phi_fixed"
+            self.mode = "4S+2D bisect_eta_fixed nu_fixed"
 
     # ------------------------------------------------------------------
     # Internal helpers


### PR DESCRIPTION
## Summary

- closes #40

- Add all 10 `ad_hoc` solver geometries (axes, modes, constant stages) to `geometries.rst`; add `ad_hoc` solver to the "Available solvers" table in `usage.rst`
- Add per-solver how-to guides (`guide_diffcalc.rst`, `guide_ad_hoc.rst`) following the [Diataxis](https://diataxis.fr) framework
- Change `diffcalc` default mode from `4S+2D mu_chi_phi_fixed` to `4S+2D bisect_eta_fixed nu_fixed` (vertical bisector)
- Update `guides.rst`, `index.rst`, `howto_benchmark.rst` navigation and cross-references
- Align diffcalc geometry property table columns with ad_hoc tables (Geometry name, Real axes, Pseudo axes, Default mode)
- Add entries to `RELEASE_NOTES.rst`

Agent: OpenCode (claudeopus46)