### PR TITLE
fix #44 ad_hoc solver version reporting and per-mode extras

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -29,6 +29,17 @@ describe future plans.
 
     Expected release: tba
 
+    Fixes
+    ~~~~~
+
+    * Expose mode extras (``psi``, ``alpha_i``, ``beta_out``, ``h2``/``k2``/``l2``, ``n_hat``) for ``ad_hoc`` geometries.  :issue:`44`
+    * Report ``ad_hoc`` and ``diffcalc`` solver versions from the backend library.  :issue:`44`
+
+    Maintenance
+    ~~~~~~~~~~~
+
+    * Require ``ad_hoc_diffractometer >= 0.8.0`` (true virtual bisecting in kappa modes).  :issue:`44`
+
 0.2.2
 ######
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
   "Topic :: Scientific/Engineering",
 ]
 dependencies = [
-  "ad_hoc_diffractometer>=0.6.0",
+  "ad_hoc_diffractometer>=0.8.0",
   "diffcalc-core",
   "hklpy2>=0.6.0",
   "numpy",

--- a/src/hklpy2_solvers/ad_hoc_solver.py
+++ b/src/hklpy2_solvers/ad_hoc_solver.py
@@ -14,11 +14,19 @@ library.  All geometries registered with the library are available.
 """
 
 import logging
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
 from typing import Any
 
 import ad_hoc_diffractometer as ahd
 import numpy as np
-from ad_hoc_diffractometer.mode import ConstraintViolation, EwaldSphereViolation
+from ad_hoc_diffractometer.mode import (
+    OPTIONAL,
+    REQUIRED,
+    ConstraintSet,
+    ConstraintViolation,
+    EwaldSphereViolation,
+)
 from ad_hoc_diffractometer.refinement import refine_lattice_bl1967
 from hklpy2.backends.base import SolverBase
 from hklpy2.backends.typing import ReflectionDict
@@ -32,6 +40,20 @@ PSEUDO_AXES = ["h", "k", "l"]
 
 DEFAULT_GEOMETRY = "fourcv"
 """Default geometry (Busing & Levy four-circle vertical)."""
+
+try:
+    _BACKEND_VERSION = _pkg_version("ad_hoc_diffractometer")
+except PackageNotFoundError:  # pragma: no cover - defensive
+    _BACKEND_VERSION = "unknown"
+
+_INPUT_EXTRA_NAMES: frozenset[str] = frozenset({"n_hat", "psi", "alpha_i", "beta_out", "h2", "k2", "l2"})
+"""Names of mode-extra parameters supplied by the user (vs. solver outputs)."""
+
+_REFERENCE_EXTRA_NAMES: frozenset[str] = frozenset({"psi", "alpha_i", "beta_out"})
+"""Reference-constraint scalar extras (set via ConstraintSet rebuild)."""
+
+_DOUBLE_DIFF_EXTRA_NAMES: tuple[str, ...] = ("h2", "k2", "l2")
+"""Double-diffraction Miller indices stored directly in mode.extras."""
 
 
 class AdHocSolver(SolverBase):
@@ -60,7 +82,7 @@ class AdHocSolver(SolverBase):
     """
 
     name = "ad_hoc"
-    version = "0.1.0"
+    version = _BACKEND_VERSION
 
     def __init__(self, geometry: str = DEFAULT_GEOMETRY, **kwargs: Any) -> None:
         available = ahd.list_geometries()
@@ -176,26 +198,115 @@ class AdHocSolver(SolverBase):
 
     @property
     def extra_axis_names(self) -> list[str]:
-        """Extra parameter names beyond the real motor axes.
+        """Ordered list of input extra parameter names for the current mode.
 
-        Always returns ``[]``.
+        Drawn from the underlying mode's ``extras`` dict (filtered to the
+        names the user is expected to supply: ``n_hat``, ``psi``,
+        ``alpha_i``, ``beta_out``, ``h2``, ``k2``, ``l2``) plus the
+        scalar name of the active :class:`ReferenceConstraint` if it
+        names one of those inputs and is not already listed.
+
+        Solver-output placeholders (e.g. ``psi`` populated by the solver
+        after :meth:`forward`) are also exposed as inputs so the user can
+        change the target value before the next forward call.
+
+        Returns ``[]`` for modes with no extras.
         """
-        return []
+        mode_obj = self._geom.mode
+        if mode_obj is None:
+            return []
+        names: list[str] = []
+        for key in mode_obj.extras:
+            if key in _INPUT_EXTRA_NAMES and key not in names:
+                names.append(key)
+        rc = getattr(mode_obj, "reference_constraint", None)
+        if rc is not None and rc.name in _INPUT_EXTRA_NAMES and rc.name not in names:
+            names.append(rc.name)
+        return names
 
     @property
     def extras(self) -> dict[str, Any]:
-        """Extra parameters beyond the real motor axes.
+        """Current values of the mode's extra parameters."""
+        out: dict[str, Any] = {}
+        mode_obj = self._geom.mode
+        if mode_obj is None:
+            return out
+        for name in self.extra_axis_names:
+            if name == "n_hat":
+                out[name] = self._geom.surface_normal
+            elif name in _REFERENCE_EXTRA_NAMES:
+                rc = getattr(mode_obj, "reference_constraint", None)
+                if rc is not None and rc.name == name:
+                    out[name] = rc.value
+                else:
+                    raw = mode_obj.extras.get(name)
+                    out[name] = None if raw in (REQUIRED, OPTIONAL) else raw
+            else:  # h2, k2, l2 (double-diffraction)
+                raw = mode_obj.extras.get(name)
+                out[name] = None if raw in (REQUIRED, OPTIONAL) else raw
+        return out
 
-        Always returns ``{}``.
+    @extras.setter
+    def extras(self, values: dict[str, Any]) -> None:
+        """Push extra parameter values into the current mode.
+
+        Routing:
+
+        * ``n_hat``  -> ``geometry.surface_normal`` (length-3 sequence or
+          ``None``).
+        * ``psi``, ``alpha_i``, ``beta_out`` -> rebuild the active
+          :class:`ConstraintSet` via ``to_dict``/``from_dict`` so the
+          :class:`ReferenceConstraint` carries the new scalar value.
+        * ``h2``, ``k2``, ``l2`` -> written directly into the mode's
+          ``extras`` dict (used by double-diffraction modes).
+
+        Unknown keys are ignored silently (consistent with hklpy2 Core
+        behaviour, which always passes the full extras dict).
         """
-        return {}
+        if not isinstance(values, dict):
+            raise TypeError(f"Must supply dict, received {values!r}")
+        if not values:
+            return
+        mode_obj = self._geom.mode
+        if mode_obj is None:
+            return
+
+        # Surface-normal vector.
+        if "n_hat" in values:
+            v = values["n_hat"]
+            if v is None:
+                self._geom.surface_normal = None
+            else:
+                self._geom.surface_normal = tuple(float(x) for x in v)
+
+        # Reference-constraint scalar (psi / alpha_i / beta_out).
+        rc = getattr(mode_obj, "reference_constraint", None)
+        if rc is not None and rc.name in _REFERENCE_EXTRA_NAMES and rc.name in values:
+            new_value = float(values[rc.name])
+            cs_dict = mode_obj.to_dict()
+            for c in cs_dict.get("constraints", []):
+                if c.get("type") == "ReferenceConstraint" and c.get("name") == rc.name:
+                    c["value"] = new_value
+                    break
+            new_cs = ConstraintSet.from_dict(cs_dict)
+            # Replace the per-mode ConstraintSet and re-select so that
+            # ``self._geom.mode`` returns the new object.
+            self._geom._modes[self._mode] = new_cs
+            self._geom.mode_name = self._mode
+
+        # Double-diffraction Miller indices (mutated in place).
+        for k in _DOUBLE_DIFF_EXTRA_NAMES:
+            if k in values:
+                # Refresh mode_obj because rebuild above may have replaced it.
+                self._geom.mode.extras[k] = float(values[k])
 
     @property
     def _summary_dict(self) -> KeyValueMap:
         """Return a summary of the geometry (modes, axes).
 
         Overrides :attr:`SolverBase._summary_dict` so that each mode
-        reports only the axes actually computed by :meth:`forward`.
+        reports both the writable axes computed by :meth:`forward`
+        (:attr:`axes_w`) and the per-mode :attr:`extra_axis_names`.
         """
         description: dict[str, Any] = {
             "name": self.geometry,
@@ -207,7 +318,7 @@ class AdHocSolver(SolverBase):
         for mode in self.modes:
             self.mode = mode
             description["modes"][mode] = {
-                "extras": [],
+                "extras": self.extra_axis_names,
                 "reals": self.axes_w,
             }
         self.mode = original_mode

--- a/src/hklpy2_solvers/diffcalc_solver.py
+++ b/src/hklpy2_solvers/diffcalc_solver.py
@@ -14,6 +14,8 @@ library (You 1999, 4S+2D six-circle geometry).
 """
 
 import logging
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
 from typing import Any
 
 from diffcalc.hkl.calc import HklCalculation
@@ -39,6 +41,11 @@ PSEUDO_AXES = ["h", "k", "l"]
 
 ENERGY_REST_KEV = 12.39842
 """Product of photon energy (keV) and wavelength (Angstrom)."""
+
+try:
+    _BACKEND_VERSION = _pkg_version("diffcalc-core")
+except PackageNotFoundError:  # pragma: no cover - defensive
+    _BACKEND_VERSION = "unknown"
 
 # ---------------------------------------------------------------------------
 # Mode definitions
@@ -107,7 +114,7 @@ class DiffcalcSolver(SolverBase):
     """
 
     name = "diffcalc"
-    version = "0.1.0"
+    version = _BACKEND_VERSION
 
     def __init__(self, geometry: str = GEOMETRY_NAME, **kwargs: Any) -> None:
         if geometry != GEOMETRY_NAME:

--- a/tests/test_ad_hoc_solver.py
+++ b/tests/test_ad_hoc_solver.py
@@ -75,7 +75,7 @@ GEOMETRY_INFO = {
     "s2d2": {
         "real_axes": ["mu", "Z", "nu", "delta"],
         "mode_count": 2,
-        "default_mode": "mu_fixed",  # library has None, solver picks first
+        "default_mode": "fixed_mu",  # library has None, solver picks first
     },
 }
 
@@ -602,18 +602,285 @@ def test_forward_inverse_roundtrip(parms, context):
     "parms, context",
     [
         pytest.param(
-            dict(mode="bisecting"),
+            dict(geometry="fourcv", mode="bisecting", expected=[]),
             does_not_raise(),
-            id="extra_axis_names is always empty",
+            id="fourcv bisecting has no extras",
+        ),
+        pytest.param(
+            dict(geometry="fourcv", mode="fixed_psi", expected=["n_hat", "psi"]),
+            does_not_raise(),
+            id="fourcv fixed_psi exposes n_hat+psi",
+        ),
+        pytest.param(
+            dict(
+                geometry="fourcv",
+                mode="double_diffraction",
+                expected=["h2", "k2", "l2"],
+            ),
+            does_not_raise(),
+            id="fourcv double_diffraction exposes h2/k2/l2",
+        ),
+        pytest.param(
+            dict(geometry="psic", mode="bisecting_vertical", expected=[]),
+            does_not_raise(),
+            id="psic bisecting_vertical has no extras",
+        ),
+        pytest.param(
+            dict(
+                geometry="psic",
+                mode="fixed_psi_vertical",
+                expected=["n_hat", "psi"],
+            ),
+            does_not_raise(),
+            id="psic fixed_psi_vertical exposes n_hat+psi",
+        ),
+        pytest.param(
+            dict(
+                geometry="psic",
+                mode="fixed_alpha_i_vertical",
+                expected=["n_hat", "alpha_i", "beta_out"],
+            ),
+            does_not_raise(),
+            id="psic fixed_alpha_i_vertical exposes alpha_i+beta_out",
+        ),
+        pytest.param(
+            dict(
+                geometry="psic",
+                mode="double_diffraction_vertical",
+                expected=["h2", "k2", "l2"],
+            ),
+            does_not_raise(),
+            id="psic double_diffraction_vertical exposes h2/k2/l2",
+        ),
+        pytest.param(
+            dict(
+                geometry="kappa6c",
+                mode="fixed_psi_horizontal",
+                expected=["n_hat", "psi"],
+            ),
+            does_not_raise(),
+            id="kappa6c fixed_psi_horizontal exposes n_hat+psi",
+        ),
+        pytest.param(
+            dict(
+                geometry="sixc",
+                mode="alpha_eq_beta_zaxis",
+                expected=["n_hat", "alpha_i", "beta_out"],
+            ),
+            does_not_raise(),
+            id="sixc alpha_eq_beta_zaxis exposes alpha_i+beta_out",
+        ),
+        pytest.param(
+            dict(
+                geometry="s2d2",
+                mode="reflectivity",
+                expected=["n_hat", "alpha_i", "beta_out"],
+            ),
+            does_not_raise(),
+            id="s2d2 reflectivity exposes alpha_i+beta_out",
         ),
     ],
 )
 def test_extra_axis_names(parms, context):
-    solver = AdHocSolver()
-    solver.mode = parms["mode"]
     with context:
-        assert solver.extra_axis_names == []
-        assert solver.extras == {}
+        solver = AdHocSolver(parms["geometry"])
+        solver.mode = parms["mode"]
+        assert solver.extra_axis_names == parms["expected"]
+        # extras dict has exactly the same keys as extra_axis_names.
+        assert list(solver.extras.keys()) == parms["expected"]
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(
+                geometry="fourcv",
+                mode="fixed_psi",
+                values={"psi": 45.0, "n_hat": (0, 0, 1)},
+                check={"psi": 45.0, "n_hat": (0.0, 0.0, 1.0)},
+            ),
+            does_not_raise(),
+            id="set psi scalar and n_hat on fourcv fixed_psi",
+        ),
+        pytest.param(
+            dict(
+                geometry="psic",
+                mode="fixed_alpha_i_vertical",
+                values={"alpha_i": 1.5, "n_hat": [1, 0, 0]},
+                check={"alpha_i": 1.5, "n_hat": (1.0, 0.0, 0.0)},
+            ),
+            does_not_raise(),
+            id="set alpha_i and n_hat on psic fixed_alpha_i_vertical",
+        ),
+        pytest.param(
+            dict(
+                geometry="fourcv",
+                mode="double_diffraction",
+                values={"h2": 1.0, "k2": 2.0, "l2": 3.0},
+                check={"h2": 1.0, "k2": 2.0, "l2": 3.0},
+            ),
+            does_not_raise(),
+            id="set h2/k2/l2 on fourcv double_diffraction",
+        ),
+        pytest.param(
+            dict(
+                geometry="fourcv",
+                mode="fixed_psi",
+                values={"n_hat": None},
+                check={"n_hat": None},
+            ),
+            does_not_raise(),
+            id="clear n_hat by setting None",
+        ),
+        pytest.param(
+            dict(
+                geometry="fourcv",
+                mode="fixed_psi",
+                values={"unknown_extra": 99.0},
+                check={},
+            ),
+            does_not_raise(),
+            id="unknown extras are silently ignored",
+        ),
+        pytest.param(
+            dict(
+                geometry="fourcv",
+                mode="fixed_psi",
+                values=[("psi", 1.0)],  # wrong type
+                check={},
+            ),
+            pytest.raises(TypeError, match=re.escape("Must supply dict")),
+            id="non-dict raises TypeError",
+        ),
+        pytest.param(
+            dict(
+                geometry="fourcv",
+                mode="fixed_psi",
+                values={},
+                check={"psi": 0.0},  # default psi unchanged
+            ),
+            does_not_raise(),
+            id="empty dict is a no-op",
+        ),
+    ],
+)
+def test_set_get_extras(parms, context):
+    with context:
+        solver = AdHocSolver(parms["geometry"])
+        solver.mode = parms["mode"]
+        solver.extras = parms["values"]
+        current = solver.extras
+        for key, expected in parms["check"].items():
+            assert current[key] == expected, f"extras[{key!r}] expected {expected!r} got {current[key]!r}"
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(
+                geometry="fourcv",
+                mode="double_diffraction",
+                extras={"h2": 0.0, "k2": 1.0, "l2": 0.0},
+                pseudos={"h": 1.0, "k": 0.0, "l": 0.0},
+            ),
+            does_not_raise(),
+            id="fourcv double_diffraction forward with h2/k2/l2",
+        ),
+        pytest.param(
+            dict(
+                geometry="psic",
+                mode="double_diffraction_vertical",
+                extras={"h2": 0.0, "k2": 1.0, "l2": 0.0},
+                pseudos={"h": 1.0, "k": 0.0, "l": 0.0},
+            ),
+            does_not_raise(),
+            id="psic double_diffraction_vertical forward with h2/k2/l2",
+        ),
+    ],
+)
+def test_forward_with_extras(parms, context):
+    """Forward calculation honours extras for implemented modes.
+
+    .. note::
+        ``ad_hoc_diffractometer`` 0.8.0 marks the surface (``alpha_i``,
+        ``beta_out``, ``alpha_eq_beta``) and ``fixed_psi_*`` modes as
+        not yet implemented.  This test exercises the ``double_diffraction``
+        family because it is implemented and uses extras (``h2``, ``k2``,
+        ``l2``).  When upstream implements the surface modes, additional
+        cases should be added here.
+    """
+    with context:
+        solver = _make_solver_with_ub(parms["geometry"])
+        solver.mode = parms["mode"]
+        solver.extras = parms["extras"]
+        solutions = solver.forward(parms["pseudos"])
+        assert len(solutions) >= 1
+        for key, value in parms["extras"].items():
+            stored = solver.extras[key]
+            if isinstance(value, (list, tuple)):
+                assert stored == tuple(float(x) for x in value)
+            else:
+                assert stored == value
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(
+                geometry="fourcv",
+                mode="fixed_psi",
+                expected_extras=["n_hat", "psi"],
+            ),
+            does_not_raise(),
+            id="summary_dict reports fixed_psi extras",
+        ),
+        pytest.param(
+            dict(
+                geometry="fourcv",
+                mode="bisecting",
+                expected_extras=[],
+            ),
+            does_not_raise(),
+            id="summary_dict reports empty extras for bisecting",
+        ),
+        pytest.param(
+            dict(
+                geometry="psic",
+                mode="double_diffraction_vertical",
+                expected_extras=["h2", "k2", "l2"],
+            ),
+            does_not_raise(),
+            id="summary_dict reports h2/k2/l2 for double_diffraction_vertical",
+        ),
+    ],
+)
+def test_summary_dict_includes_extras(parms, context):
+    with context:
+        solver = AdHocSolver(parms["geometry"])
+        sd = solver._summary_dict
+        assert sd["modes"][parms["mode"]]["extras"] == parms["expected_extras"]
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(),
+            does_not_raise(),
+            id="AdHocSolver.version matches backend library",
+        ),
+    ],
+)
+def test_solver_version(parms, context):
+    from importlib.metadata import version as _pkg_version
+
+    with context:
+        assert AdHocSolver.version == _pkg_version("ad_hoc_diffractometer")
+        # Sanity: not the legacy hardcoded value.
+        assert AdHocSolver.version != "0.1.0"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_diffcalc_solver.py
+++ b/tests/test_diffcalc_solver.py
@@ -1148,3 +1148,22 @@ def test_summary_dict_all_modes(parms, context):
             expected = solver.axes_w
             actual = sdict["modes"][mode_name]["reals"]
             assert actual == expected, f"Mode {mode_name!r}: expected writable {expected}, got {actual}"
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(),
+            does_not_raise(),
+            id="DiffcalcSolver.version matches diffcalc-core package",
+        ),
+    ],
+)
+def test_solver_version(parms, context):
+    from importlib.metadata import version as _pkg_version
+
+    with context:
+        assert DiffcalcSolver.version == _pkg_version("diffcalc-core")
+        # Sanity: not the legacy hardcoded value.
+        assert DiffcalcSolver.version != "0.1.0"


### PR DESCRIPTION
- closes #44

## Summary

- `AdHocSolver.version` and `DiffcalcSolver.version` are now resolved at
  import time via `importlib.metadata.version(...)` so they report the
  actual backend library version (`ad_hoc_diffractometer` / `diffcalc-core`)
  instead of the hard-coded `0.1.0`.
- `AdHocSolver` now exposes per-mode extras (`psi`, `alpha_i`, `beta_out`,
  `h2`/`k2`/`l2`, `n_hat`) via `extra_axis_names` / `extras` (getter +
  setter) so `hklpy2.Core` can drive modes that need them.  `n_hat` is
  routed to `geometry.surface_normal`; scalar reference constraints are
  applied by rebuilding the active `ConstraintSet` via
  `to_dict()`/`from_dict()`; `h2`/`k2`/`l2` are written directly into
  `mode.extras`.
- `_summary_dict` now reports the real per-mode extras instead of `[]`.
- `pyproject.toml` requires `ad_hoc_diffractometer >= 0.8.0` (true
  virtual bisecting in kappa modes; mode-name standardisation already
  applied in v0.7.0 — `s2d2` default mode test updated accordingly).
- 23 new parametrized test cases (extras matrix across fourcv / psic /
  kappa6c / sixc / s2d2 / fourcv-double-diffraction; set/get round-trips
  including `TypeError` on non-dict input; forward + extras for the
  implemented `double_diffraction` family; per-mode extras in
  `_summary_dict`; backend-version sanity for both solvers).

## Verification

- `pre-commit run --all-files` clean
- `pytest ./tests` — 201 passed, coverage 93%
- `make -C docs html` — build succeeded, no warnings

## Notes

`ad_hoc_diffractometer` 0.8.0 still marks the surface (`alpha_i`,
`beta_out`, `alpha_eq_beta`) and `fixed_psi_*` modes as not-yet
implemented in `forward()`.  This wrapper is now ready for them: as soon
as upstream lands the implementations, no wrapper change is needed and
the existing extras plumbing will carry the values through.

Agent: OpenCode (claudeopus47)