### PR TITLE
ci #48 add Python 3.14-dev to test matrix (allowed to fail)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,18 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-latest
+    # Allow experimental Python versions to fail without failing the
+    # workflow as a whole (informational signal only).  Required jobs
+    # still gate merges via branch protection.
+    continue-on-error: ${{ matrix.experimental || false }}
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
+        experimental: [false]
+        include:
+          - python-version: "3.14-dev"
+            experimental: true
 
     steps:
       - uses: actions/checkout@v6
@@ -25,6 +33,7 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
 
       - name: Install package with dev dependencies
         run: pip install -e ".[dev]"

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -39,6 +39,7 @@ describe future plans.
     Maintenance
     ~~~~~~~~~~~
 
+    * CI: add Python 3.14-dev to the test matrix (allowed to fail).  :issue:`48`
     * Enforce 100% line and branch coverage in CI (``fail_under = 100`` in ``pyproject.toml``).  :issue:`46`
     * Require ``ad_hoc_diffractometer >= 0.8.0`` (true virtual bisecting in kappa modes).  :issue:`44`
 


### PR DESCRIPTION
- closes #48

## Summary

- Add a fifth ``test`` matrix entry for Python ``3.14-dev`` via
  ``matrix.include`` with ``experimental: true``.
- Add job-level ``continue-on-error: ${{ matrix.experimental || false }}``
  so the 3.14-dev job is informational only and does not gate merges.
  The four supported versions (3.10–3.13) still run with the normal
  pass/fail semantics and ``fail-fast: false`` keeps them independent.
- Pass ``allow-prereleases: true`` to ``actions/setup-python@v6`` so
  the pre-release build resolves correctly.

## Verification

- ``yaml.safe_load`` round-trip on ``ci.yml`` confirms the matrix
  expansion is well-formed.
- ``pre-commit run --all-files`` clean.
- The 3.14-dev job will appear on this PR; we will see it pass or fail
  alongside the four required jobs.

## Stretch goal

Once 3.14-dev stays green for several weeks, promote it to required in
a follow-up.

Agent: OpenCode (claudeopus47)