### PR TITLE
fix #56 honour r1/r2 arguments in AdHocSolver.calculate_UB

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -29,6 +29,11 @@ describe future plans.
 
     Expected release: tba
 
+    Fixes
+    ~~~~~
+
+    * Honour ``r1`` / ``r2`` arguments in ``AdHocSolver.calculate_UB``.  :issue:`56`
+
 0.3.1
 ######
 

--- a/src/hklpy2_solvers/ad_hoc_solver.py
+++ b/src/hklpy2_solvers/ad_hoc_solver.py
@@ -179,11 +179,31 @@ class AdHocSolver(SolverBase):
         self._geom.wavelength = wl
 
     def calculate_UB(self, r1: ReflectionDict, r2: ReflectionDict) -> Matrix3x3:
-        """Calculate the UB matrix using two reflections (Busing & Levy)."""
+        """Calculate the UB matrix using two reflections (Busing & Levy).
+
+        The ``r1`` and ``r2`` arguments are the contractual source of
+        truth: any prior reflections held by the underlying
+        ``ad_hoc_diffractometer`` sample are cleared and the two named
+        reflections are inserted (so ``setor0`` / ``setor1`` are
+        correctly designated) before UB is computed.  This mirrors
+        :meth:`hklpy2.backends.hkl_soleil.HklSolver.calculate_UB` and
+        avoids depending on whatever sync state ``Core.update_solver``
+        happens to have left behind (see :issue:`56` and upstream
+        ``bluesky/hklpy2`` issue #397).
+        """
         if not self._lattice:
             raise SolverError("Lattice must be set before calculating UB.")
 
-        ahd.ub_from_two_reflections_bl1967(self._geom.sample)
+        # Honour the caller-supplied reflections, regardless of any
+        # stale solver-side state.
+        self.removeAllReflections()
+        self.addReflection(r1)
+        self.addReflection(r2)
+
+        try:
+            ahd.ub_from_two_reflections_bl1967(self._geom.sample)
+        except ValueError as exc:
+            raise SolverError(str(exc)) from exc
         return self._geom.sample.UB.tolist()
 
     @property

--- a/tests/test_ad_hoc_solver.py
+++ b/tests/test_ad_hoc_solver.py
@@ -7,6 +7,7 @@ import re
 from contextlib import nullcontext as does_not_raise
 
 import pytest
+from hklpy2.exceptions import SolverError
 
 from hklpy2_solvers.ad_hoc_solver import DEFAULT_GEOMETRY, PSEUDO_AXES, AdHocSolver
 
@@ -460,6 +461,120 @@ def test_calculate_ub_no_lattice(parms, context):
     solver.addReflection(FOURCV_R2)
     with context:
         solver.calculate_UB(FOURCV_R1, FOURCV_R2)
+
+
+# Distinct reflections used to verify that ``calculate_UB`` honours its
+# arguments rather than reaching into the solver's existing reflection
+# state.  ``DISTRACTOR_R1`` / ``DISTRACTOR_R2`` are well-separated in
+# reciprocal space from ``FOURCV_R1`` / ``FOURCV_R2`` so the resulting
+# UBs are visibly different.
+DISTRACTOR_R1 = {
+    "name": "distractor1",
+    "pseudos": {"h": 1.0, "k": 1.0, "l": 0.0},
+    "reals": {"omega": THETA_100, "chi": 0, "phi": 45, "ttheta": TTH_100},
+    "wavelength": WAVELENGTH,
+}
+DISTRACTOR_R2 = {
+    "name": "distractor2",
+    "pseudos": {"h": 0.0, "k": 0.0, "l": 1.0},
+    "reals": {"omega": THETA_100, "chi": 90, "phi": 0, "ttheta": TTH_100},
+    "wavelength": WAVELENGTH,
+}
+# Two pseudos-collinear reflections (both along h) -- the underlying
+# ``ub_from_two_reflections_bl1967`` rejects these, surfacing as a
+# ``SolverError`` from ``calculate_UB``.  Used to cover the
+# ValueError -> SolverError translation branch.
+COLINEAR_R1 = {
+    "name": "col1",
+    "pseudos": {"h": 1.0, "k": 0.0, "l": 0.0},
+    "reals": {"omega": THETA_100, "chi": 0, "phi": 0, "ttheta": TTH_100},
+    "wavelength": WAVELENGTH,
+}
+COLINEAR_R2 = {
+    "name": "col2",
+    "pseudos": {"h": 2.0, "k": 0.0, "l": 0.0},
+    "reals": {"omega": 2 * THETA_100, "chi": 0, "phi": 0, "ttheta": 2 * TTH_100},
+    "wavelength": WAVELENGTH,
+}
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(
+                preload=[DISTRACTOR_R1, DISTRACTOR_R2],
+                r1=FOURCV_R1,
+                r2=FOURCV_R2,
+                expected_or1="r1",
+                expected_or2="r2",
+            ),
+            does_not_raise(),
+            id="calculate_UB honours r1/r2 over stale preloaded reflections",
+        ),
+        pytest.param(
+            dict(
+                preload=[],
+                r1=FOURCV_R1,
+                r2=FOURCV_R2,
+                expected_or1="r1",
+                expected_or2="r2",
+            ),
+            does_not_raise(),
+            id="calculate_UB honours r1/r2 with no preloaded reflections",
+        ),
+        pytest.param(
+            dict(
+                preload=[FOURCV_R1, FOURCV_R2, DISTRACTOR_R1, DISTRACTOR_R2],
+                r1=DISTRACTOR_R1,
+                r2=DISTRACTOR_R2,
+                expected_or1="distractor1",
+                expected_or2="distractor2",
+            ),
+            does_not_raise(),
+            id="calculate_UB picks named pair from a longer preloaded list",
+        ),
+        pytest.param(
+            dict(
+                preload=[],
+                r1=COLINEAR_R1,
+                r2=COLINEAR_R2,
+                expected_or1=None,
+                expected_or2=None,
+            ),
+            pytest.raises(SolverError),
+            id="calculate_UB translates ValueError to SolverError on colinear pair",
+        ),
+    ],
+)
+def test_calculate_ub_honours_arguments(parms, context):
+    """``calculate_UB(r1, r2)`` MUST honour its arguments.
+
+    Regression for :issue:`56`: the previous implementation ignored
+    ``r1`` and ``r2`` and computed UB from whatever reflections were
+    designated as ``or0``/``or1`` on the underlying ad_hoc sample.
+    The current implementation clears the solver's reflection state
+    and inserts exactly the two reflections the caller named, so the
+    AHD ``or1``/``or2`` slots end up naming ``r1`` and ``r2``.
+    """
+    solver = AdHocSolver("fourcv")
+    solver.lattice = dict(SI_LATTICE)
+    for refl in parms["preload"]:
+        solver.addReflection(refl)
+    with context:
+        ub = solver.calculate_UB(parms["r1"], parms["r2"])
+        # UB is a 3x3 matrix.
+        assert len(ub) == 3
+        assert all(len(row) == 3 for row in ub)
+        # The AHD orienting-reflection slots now name r1/r2.
+        refls = solver._geom.sample.reflections
+        assert refls._or1_name == parms["expected_or1"]
+        assert refls._or2_name == parms["expected_or2"]
+        # And only those two reflections remain on the solver side.
+        assert list(refls._data.keys()) == [
+            parms["expected_or1"],
+            parms["expected_or2"],
+        ]
 
 
 @pytest.mark.parametrize(
@@ -1418,8 +1533,11 @@ def test_refine_lattice_success(parms, context):
     }
     solver.addReflection(r1)
     solver.addReflection(r2)
-    solver.addReflection(r3)
     solver.calculate_UB(r1, r2)
+    # ``calculate_UB`` clears any extra reflections (it now honours its
+    # own r1/r2 arguments by resetting the solver's reflection list).
+    # Re-add r3 so ``refineLattice`` sees the 3 reflections it needs.
+    solver.addReflection(r3)
 
     with context:
         result = solver.refineLattice([r1, r2, r3])


### PR DESCRIPTION
- closes #56
- related: bluesky/hklpy2#397 (load-bearing upstream contract gap)

## Summary

`AdHocSolver.calculate_UB(r1, r2)` previously ignored its `r1` / `r2`
arguments and asked the underlying `ad_hoc_diffractometer` library to
compute UB from whatever reflections happened to be designated as
`or0`/`or1` on the geometry's sample.  That assumption holds only if
something has just re-pushed the sample to the solver, which the
upstream `Core.add_reflection` path does not currently guarantee
(see bluesky/hklpy2#397).  As a result, the public
`Core.calc_UB(r3, r4)` path failed for any reflections other than the
first two ever added.

This change makes `calculate_UB` self-sufficient, mirroring
`HklSoleilSolver.calculate_UB`:

```python
self.removeAllReflections()
self.addReflection(r1)
self.addReflection(r2)
ahd.ub_from_two_reflections_bl1967(self._geom.sample)
```

The two named reflections are now the contractual source of truth,
regardless of upstream sync state.  `ValueError` from the underlying
library is translated into `SolverError` for consistency with the
solver's other error-translation paths.

## Why this is defence-in-depth, not a workaround

The deeper bug -- `Core.add_reflection` /
`set_orientation_reflections` not flagging `_SolverDirty.SAMPLE` -- is
filed upstream at bluesky/hklpy2#397.  Even after that lands,
`calculate_UB(r1, r2)` should honour its named arguments as a matter
of contract clarity (the signature names them).  This change aligns
the AdHocSolver with the well-tested behaviour of the HklSoleilSolver.

## Tests

Added `test_calculate_ub_honours_arguments` (parametrised, per
`AGENTS.md`):

* honours `r1`/`r2` over a stale preloaded pair (the notebook scenario)
* honours `r1`/`r2` with no preloaded reflections
* picks the named pair from a longer preloaded list (4 reflections)
* translates `ValueError` to `SolverError` on a colinear pair

Adjusted `test_refine_lattice_success` to re-add the third reflection
after `calculate_UB`, since the new (and previously implicit
`HklSoleilSolver`) behaviour clears the solver's reflection list.

## Verification

* `pytest tests/` -- 227 passed (was 223; +4 from the new
  parametrised test).
* `pytest tests/ --cov=src/hklpy2_solvers --cov-branch` -- 100% line
  and branch coverage.
* `pre-commit run --all-files` -- clean.
* `dev_benchmark-sapphire.ipynb` (the original failing notebook) now
  runs end-to-end with `solver='ad_hoc'`.

## Release notes

Added one-line `Fixes` entry inside the unreleased SEMVER comment
block in `RELEASE_NOTES.rst`:

```rst
* Honour ``r1`` / ``r2`` arguments in ``AdHocSolver.calculate_UB``.  :issue:`56`
```

Agent: OpenCode (claudeopus47)