### PR TITLE
docs #60 remove cross-references between solver implementations

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -35,6 +35,11 @@ describe future plans.
     * Honour ``r1`` / ``r2`` arguments in ``AdHocSolver.calculate_UB``.  :issue:`56`
     * Honour ``r1`` / ``r2`` arguments in ``DiffcalcSolver.calculate_UB``.  :issue:`58`
 
+    Maintenance
+    ~~~~~~~~~~~
+
+    * Remove cross-references between solver implementations.  :issue:`60`
+
 0.3.1
 ######
 

--- a/src/hklpy2_solvers/ad_hoc_solver.py
+++ b/src/hklpy2_solvers/ad_hoc_solver.py
@@ -185,11 +185,7 @@ class AdHocSolver(SolverBase):
         truth: any prior reflections held by the underlying
         ``ad_hoc_diffractometer`` sample are cleared and the two named
         reflections are inserted (so ``setor0`` / ``setor1`` are
-        correctly designated) before UB is computed.  This mirrors
-        :meth:`hklpy2.backends.hkl_soleil.HklSolver.calculate_UB` and
-        avoids depending on whatever sync state ``Core.update_solver``
-        happens to have left behind (see :issue:`56` and upstream
-        ``bluesky/hklpy2`` issue #397).
+        correctly designated) before UB is computed.  See :issue:`56`.
         """
         if not self._lattice:
             raise SolverError("Lattice must be set before calculating UB.")
@@ -427,9 +423,10 @@ class AdHocSolver(SolverBase):
     def sample(self, value: dict) -> None:
         """Set the crystalline sample, pushing lattice and reflections.
 
-        Overrides :class:`~hklpy2.backends.base.SolverBase` to mirror the
-        pattern used by ``DiffcalcSolver``: after storing the dict, the
-        lattice is pushed and all reflections are re-added.
+        Overrides :class:`~hklpy2.backends.base.SolverBase` so that, after
+        storing the dict, the lattice is pushed into
+        ``ad_hoc_diffractometer`` immediately and the reflections are
+        re-added in declared order.
         """
         if not isinstance(value, dict):
             raise TypeError(f"Must supply dictionary, received {value!r}")

--- a/src/hklpy2_solvers/diffcalc_solver.py
+++ b/src/hklpy2_solvers/diffcalc_solver.py
@@ -244,13 +244,9 @@ class DiffcalcSolver(SolverBase):
 
         The ``r1`` and ``r2`` arguments are the contractual source of
         truth: any reflections previously held by the underlying
-        ``diffcalc`` ``UBCalculation`` are cleared and the two named
-        reflections are inserted before UB is computed.  This mirrors
-        :meth:`hklpy2.backends.hkl_soleil.HklSolver.calculate_UB` and
-        :meth:`hklpy2_solvers.ad_hoc_solver.AdHocSolver.calculate_UB`,
-        and avoids depending on whatever sync state
-        ``Core.update_solver`` happens to have left behind (see
-        :issue:`58` and upstream ``bluesky/hklpy2`` issue #397).
+        ``diffcalc`` :class:`~diffcalc.ub.calc.UBCalculation` are
+        cleared and the two named reflections are inserted before UB
+        is computed.  See :issue:`58`.
         """
         # Ensure lattice is set
         if self._ubcalc.crystal is None:
@@ -401,18 +397,19 @@ class DiffcalcSolver(SolverBase):
     def sample(self, value: dict) -> None:
         """Set the crystalline sample, pushing lattice and reflections into diffcalc.
 
-        Overrides :class:`~hklpy2.backends.base.SolverBase` to mirror the
-        pattern used by ``HklSolver``: after storing the dict, the lattice is
-        immediately pushed into :attr:`_ubcalc` and all reflections are
-        re-added in ``order`` sequence.  This ensures that
-        :meth:`calculate_UB` can find a crystal when called by
-        ``hklpy2.Core.calc_UB()`` (fixes :issue:`25`).
+        Overrides :class:`~hklpy2.backends.base.SolverBase` so that, after
+        storing the dict, the lattice is immediately pushed into
+        :attr:`_ubcalc` and all reflections are re-added in ``order``
+        sequence.  This ensures that :meth:`calculate_UB` can find a
+        crystal when called by ``hklpy2.Core.calc_UB()`` (fixes
+        :issue:`25`).
         """
         if not isinstance(value, dict):
             raise TypeError(f"Must supply dictionary, received {value!r}")
         self._sample = value
 
-        # Push lattice into diffcalc immediately (mirrors HklSolver behaviour).
+        # Push lattice into diffcalc immediately so that ``calculate_UB``
+        # has a crystal to work with.
         if "lattice" in value:
             self.lattice = value["lattice"]
 
@@ -480,8 +477,7 @@ class DiffcalcSolver(SolverBase):
         .. note::
             ``set_reals`` is not yet part of
             :class:`~hklpy2.backends.base.SolverBase`; it was introduced via
-            the hklpy2 presets feature and is currently only defined on
-            ``HklSolver``.  Tracked upstream as
+            the hklpy2 presets feature.  Tracked upstream as
             `bluesky/hklpy2#347 <https://github.com/bluesky/hklpy2/issues/347>`_.
         """
         if not isinstance(reals, dict):


### PR DESCRIPTION
- closes #60

## Summary

Each solver implementation now describes its own contract without
naming siblings or upstream cousins.  Stripped cross-references from
docstrings and comments in `ad_hoc_solver.py` and `diffcalc_solver.py`.

## Changes

`src/hklpy2_solvers/ad_hoc_solver.py`:

* `calculate_UB` docstring -- drop reference to another solver class.
* `sample` setter docstring -- drop reference to another solver class.

`src/hklpy2_solvers/diffcalc_solver.py`:

* `calculate_UB` docstring -- drop references to two other solver
  classes; tighten the wording to focus on this solver's contract.
* `sample` setter docstring -- drop reference to another solver class.
* Inline comment in `sample` setter -- drop "mirrors X behaviour"
  parenthetical.
* `set_reals` docstring -- drop reference to another solver class
  (the upstream issue link is preserved).

No behaviour change, no new tests required.  The substantive contract
of each method (what it does, why) is unchanged.

## Verification

* `pytest tests/` -- 231 passed.
* `pytest tests/ --cov=src/hklpy2_solvers --cov-branch` -- 100% line
  and branch coverage.
* `pre-commit run --all-files` -- clean.

## Release notes

Added `Maintenance` subsection to the unreleased SEMVER comment block
in `RELEASE_NOTES.rst`:

```rst
* Remove cross-references between solver implementations.  :issue:`60`
```

Agent: OpenCode (claudeopus47)