### PR TITLE
feat #66 add vertical kappa four-circle cross-validation group (PR3)

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -34,6 +34,7 @@ describe future plans.
 
     * Add horizontal four-circle cross-validation group against ``hkl_soleil``.  :issue:`67`
     * Add vertical four-circle cross-validation suite against ``hkl_soleil``.  :issue:`50`
+    * Add vertical kappa four-circle cross-validation group against ``hkl_soleil``.  :issue:`66`
 
     Fixes
     ~~~~~

--- a/tests/test_cross_validation.py
+++ b/tests/test_cross_validation.py
@@ -17,10 +17,21 @@ Groups currently covered:
 * **horizontal four-circle bisecting** (PR2, :issue:`67`): scattering
   plane rotated 90 deg about the beam; reference ``hkl_soleil/E6C``
   in ``bissector_horizontal`` mode (libhkl's ``E4CH`` is structurally
-  a vertical-style ``bissector`` and provides no independent signal).
+  a vertical-style ``bissector`` and provides no independent signal;
+  see :issue:`72`).
+* **kappa four-circle bisecting, vertical plane** (PR3, :issue:`66`):
+  kappa-axis goniometer with ``(komega, kappa, kphi)`` replacing the
+  eulerian ``(omega, chi, phi)`` triad; reference
+  ``hkl_soleil/K4CV``.  Six-circle kappa peers (``K6C``, ``kappa6c``)
+  participate by pinning ``mu`` / detector-2 to zero in their
+  ``bissector_vertical`` / ``bisecting_vertical`` modes.  The
+  ``kappa`` axis is constrained to ``[-100, 100] deg`` to match
+  physical kappa-arm ranges.  A kappa-horizontal group is deferred:
+  K6C ``bissector_horizontal`` bootstrap is delicate and warrants
+  its own PR; see :issue:`75`.
 
-Later PRs add kappa (:issue:`66`), six-circle and beyond (:issue:`64`),
-and a dedicated CI workflow (:issue:`65`).
+Later PRs add six-circle and beyond (:issue:`64`), and a dedicated CI
+workflow (:issue:`65`).
 
 The module skips silently when libhkl is not importable via
 ``gobject-introspection`` (e.g. on default GitHub-hosted runners that
@@ -174,12 +185,63 @@ HORIZONTAL_GROUP = {
     ),
 }
 
+# Kappa four-circle bisecting cross-validation group, VERTICAL plane.
+#
+# Each entry is a peer to ``hkl_soleil/K4CV``: kappa-axis goniometer
+# where ``(komega, kappa, kphi)`` replaces the eulerian
+# ``(omega, chi, phi)`` triad.  The bisecting condition in kappa
+# coordinates reads ``komega = ttheta / 2`` (analog of
+# ``omega = ttheta / 2`` in the eulerian groups), and the second
+# reflection ``(1, 1, 0)`` is brought into the bisecting plane by a
+# 90 deg ``kphi`` rotation (analog of ``phi = 90``).
+#
+# ``reals=`` lists preserve each solver's canonical axis order; only
+# axis-name renames are applied:
+#
+# * ``K4CV``: ``tth -> ttheta`` (identity otherwise).
+# * ``K6C``: ``delta -> ttheta`` (mu / gamma pinned to 0 by
+#   ``bissector_vertical`` mode; left as backend names).
+# * ``kappa4cv``: identity (canonical already uses ``ttheta``).
+# * ``kappa6c``: ``delta -> ttheta`` (mu / nu pinned to 0 by
+#   ``bisecting_vertical`` mode; left as backend names).
+#
+# ``ad_hoc/kappa4ch`` belongs in the horizontal kappa group, not
+# here.  ``diffcalc`` has no kappa-axis geometry, so it does not
+# participate in either kappa group.
+KAPPA_VERTICAL_GROUP = {
+    "k4cv": dict(
+        solver="hkl_soleil",
+        geometry="K4CV",
+        reals=["komega", "kappa", "kphi", "ttheta"],
+        mode="bissector",
+    ),
+    "k6c": dict(
+        solver="hkl_soleil",
+        geometry="K6C",
+        reals=["mu", "komega", "kappa", "kphi", "gamma", "ttheta"],
+        mode="bissector_vertical",
+    ),
+    "kappa4cv": dict(
+        solver="ad_hoc",
+        geometry="kappa4cv",
+        reals=["komega", "kappa", "kphi", "ttheta"],
+        mode="bisecting",
+    ),
+    "kappa6c": dict(
+        solver="ad_hoc",
+        geometry="kappa6c",
+        reals=["mu", "komega", "kappa", "kphi", "nu", "ttheta"],
+        mode="bisecting_vertical",
+    ),
+}
+
 # Cross-validation groups.  Each group maps to its peer dict and the
 # name of the reference entry within that dict; the per-group bootstrap
 # recipe is selected by ``BOOTSTRAP_BY_GROUP`` below.
 GROUPS = {
     "vertical": dict(entries=VERTICAL_GROUP, reference="e4cv"),
     "horizontal": dict(entries=HORIZONTAL_GROUP, reference="e6c"),
+    "kappa_vertical": dict(entries=KAPPA_VERTICAL_GROUP, reference="k4cv"),
 }
 
 # Known cross-solver |2theta| discrepancies tracked in their own issues.
@@ -200,6 +262,8 @@ KNOWN_TTH_DISAGREEMENTS = {
     ("horizontal", "fourch", "triclinic", (0, 0, 6)): "issue #68",
     ("horizontal", "psic", "triclinic", (0, 0, 6)): "issue #68",
     ("horizontal", "diffcalc", "triclinic", (0, 0, 6)): "issue #68",
+    ("kappa_vertical", "kappa4cv", "triclinic", (0, 0, 6)): "issue #68",
+    ("kappa_vertical", "kappa6c", "triclinic", (0, 0, 6)): "issue #68",
 }
 
 # Known forward-solution gaps: parameter cases where ``forward()`` itself
@@ -321,9 +385,45 @@ def _rough_horizontal_positions(geometry, tth1, tth2):
     return p1, p2
 
 
+def _rough_kappa_vertical_positions(geometry, tth1, tth2):
+    """Geometry-appropriate rough motor settings for vertical-kappa bootstrap.
+
+    Kappa goniometers use ``(komega, kappa, kphi)`` instead of the
+    eulerian ``(omega, chi, phi)`` triad.  The bisecting condition in
+    kappa coordinates is ``komega = ttheta / 2`` with ``kappa = 0``
+    reducing the kappa goniometer to a pure four-circle in this
+    submanifold; ``(1, 1, 0)`` is brought into the bisecting plane by
+    ``kphi = 90`` (analog of ``phi = 90``).  Each writable bootstrap
+    angle EXCEPT ``kappa`` is nudged off the exact bisecting solution
+    by a deterministic random offset bounded by
+    ``BOOTSTRAP_NUDGE_DEG`` so the two reflections used for
+    ``calc_UB`` are linearly independent.  ``kappa`` is held at 0 so
+    that the bootstrap UB stays in the four-circle submanifold; this
+    matters for triclinic samples where a small ``kappa`` nudge
+    perturbs the UB enough that the post-bootstrap forward solution
+    for ``(1, 1, 0)`` would require ``|kappa| > 100 deg`` and exceed
+    the physical kappa-arm range.  Six-circle kappa peers leave the
+    pinned axes (``mu``, second-detector) at zero so the
+    ``bissector_vertical`` / ``bisecting_vertical`` mode constraint
+    is satisfied at bootstrap.
+    """
+    p0 = {axis: 0.0 for axis in geometry.real_axis_names}
+    p1 = dict(p0)
+    p2 = dict(p0)
+    d1_tth, d1_om, d2_tth, d2_om, d2_kphi = _nudges(seed_offset=2, count=5)
+    p1.update(ttheta=tth1 + d1_tth, komega=tth1 / 2 + d1_om)
+    p2.update(
+        ttheta=tth2 + d2_tth,
+        komega=tth2 / 2 + d2_om,
+        kphi=90 + d2_kphi,
+    )
+    return p1, p2
+
+
 BOOTSTRAP_BY_GROUP = {
     "vertical": _rough_vertical_positions,
     "horizontal": _rough_horizontal_positions,
+    "kappa_vertical": _rough_kappa_vertical_positions,
 }
 
 
@@ -346,8 +446,24 @@ def _build_simulator(group_name, entry_info, sample_dict):
     sim = hklpy2.creator(**kwargs)
     sim.core.mode = mode
     sim.add_sample(**sample_dict)
-    sim.core.constraints["chi"].limits = -100, 100
-    sim.core.constraints["phi"].limits = -120, 120
+    # Per-axis constraint widening.  PR1/PR2 chose ``chi: [-100, 100]``
+    # / ``phi: [-120, 120]`` deliberately - libhkl's ``bissector`` mode
+    # picks different solution branches at wider ranges, so the
+    # eulerian groups must keep those bounds.  Kappa peers use
+    # ``(komega, kappa, kphi)`` instead; ``kappa`` is constrained to
+    # ``[-100, 100] deg`` to match the physical range of typical
+    # kappa-arm goniometers.  Apply each only if the axis exists on
+    # this solver.
+    _CONSTRAINTS = {
+        "chi": (-100, 100),
+        "phi": (-120, 120),
+        "kappa": (-100, 100),
+        "kphi": (-180, 180),
+        "komega": (-180, 180),
+    }
+    for axis_name, limits in _CONSTRAINTS.items():
+        if axis_name in sim.core.constraints:
+            sim.core.constraints[axis_name].limits = limits
 
     tth1 = _bragg_two_theta(sim, *HKL_BOOTSTRAP_1)
     tth2 = _bragg_two_theta(sim, *HKL_BOOTSTRAP_2)


### PR DESCRIPTION
- closes #66
- refs #50

## Summary

PR3 of the cross-validation campaign (#50).  Adds the kappa-vertical
bisecting peer group covering kappa-axis goniometers, where
``(komega, kappa, kphi)`` replace the eulerian ``(omega, chi, phi)``
triad.

## Scope

* **Kappa vertical bisecting group**, four peer entries:
    * ``hkl_soleil/K4CV`` (reference, ``bissector``)
    * ``hkl_soleil/K6C`` (``bissector_vertical``)
    * ``ad_hoc/kappa4cv`` (``bisecting``)
    * ``ad_hoc/kappa6c`` (``bisecting_vertical``)
* ``diffcalc`` does not participate (no kappa-axis geometry).
* Six-circle kappa peers (``K6C``, ``kappa6c``) pin ``mu`` and the
  second detector to zero per mode, leaving them as backend names in
  ``reals=``.
* ``ad_hoc/kappa4ch`` is **not** in this group; it belongs in the
  kappa-horizontal group, deferred to **PR3b** (:issue:`75`).

## Key implementation choices

* **Kappa-axis constraint ``[-100, 100] deg``** matches physical
  kappa-arm range (per maintainer guidance).
* **Bootstrap nudge holds ``kappa = 0``** in vertical bisecting.
  Nudging ``kappa`` away from 0 perturbs the bootstrap UB enough
  that the refined ``forward((1, 1, 0))`` on triclinic requires
  ``|kappa| > 100 deg`` and becomes infeasible at the physical
  constraint.  The four in-plane writable angles (``komega1``,
  ``komega2``, ``ttheta1``, ``ttheta2``, ``kphi2``) still get the
  ``+- 2 deg`` random nudges so the two reflections used for
  ``calc_UB`` remain linearly independent.
* **Per-axis constraint dispatch** added in ``_build_simulator``:
  ``chi: [-100, 100]``, ``phi: [-120, 120]`` preserved for the
  eulerian groups (libhkl ``bissector`` mode picks different
  solution branches at wider ranges, per PR1/PR2 finding);
  ``kappa: [-100, 100]`` for the kappa group; ``kphi`` / ``komega``
  wide.
* ``reals=`` positional-order audit: all four entries preserve each
  solver's canonical axis order; only renames applied
  (``tth -> ttheta``, ``delta -> ttheta`` on six-circle peers).

## Issues opened / updated during PR3

* **#75** - PR3b sub-issue for the kappa-horizontal group.
  Captures the ``K6C bissector_horizontal`` bootstrap fragility
  empirically observed during PR3 (degenerate U matrix on the
  naive ``mu = tth/2`` recipe; ``NoForwardSolutions`` on the
  ``komega = tth/2`` recipe; ``axes_w`` inconsistent with what
  ``forward()`` actually picks) and the dispatch strategy that
  PR3b will need (4-axis kappa ``komega = tth/2`` vs 6-axis kappa
  ``mu = tth/2``).
* **#74** - correction comment added.  The earlier headline
  ("kappa4cv and kappa4ch return bit-identical angles") was an
  artifact of probing only symmetric reflections; sapphire
  ``(0, 1, 2)`` distinguishes them on ``kphi`` (and possibly other
  axes), so ``kappa4ch`` is not an alias of ``kappa4cv``.  Slated
  to close as not-a-bug once PR3b validates ``kappa4ch`` in the
  horizontal context.

## Test results

* ``pytest tests/test_cross_validation.py``:
  **166 passed, 11 xfailed** (up from PR2's 119/9).
* New xfailed cases: 2 kappa-vertical triclinic-(0, 0, 6) under #68.
* Full repo suite: **397 passed, 11 xfailed**.
* ``coverage report``: **100% line / branch** maintained.
* ``pre-commit run --all-files``: clean.

## Branch strategy

Sequential PR pattern per the campaign plan: PR3 branches from
current ``main``, merges via squash, then PR3b (#75) and PR4 (#64)
branch from updated ``main`` afterwards.

Agent: OpenCode (claudeopus47)