### PR TITLE
feat #64 add six-circle bisecting peers to cross-validation suite (PR4)

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -35,6 +35,7 @@ describe future plans.
     * Add ``cross-validation.yml`` workflow running libhkl-backed tests via conda-forge.  :issue:`65`
     * Add horizontal four-circle cross-validation group against ``hkl_soleil``.  :issue:`67`
     * Add horizontal kappa cross-validation group against ``hkl_soleil``.  :issue:`75`
+    * Add six-circle bisecting peers to cross-validation groups.  :issue:`64`
     * Add vertical four-circle cross-validation suite against ``hkl_soleil``.  :issue:`50`
     * Add vertical kappa four-circle cross-validation group against ``hkl_soleil``.  :issue:`66`
 

--- a/tests/test_cross_validation.py
+++ b/tests/test_cross_validation.py
@@ -41,8 +41,22 @@ Groups currently covered:
   ``ttheta``) because libhkl rejects the naive recipes with a
   degenerate U matrix or ``NoForwardSolutions``.
 
-Later PRs add six-circle and beyond (:issue:`64`), and a dedicated CI
-workflow (:issue:`65`).
+* **six-circle bisecting peers** (PR4, :issue:`64`): adds entries that
+  fit naturally into the existing eulerian groups rather than forming
+  a new group dict.  ``ad_hoc/sixc bisecting_4c`` joins
+  ``EULER_VERTICAL_GROUP`` (``alpha`` / ``gamma`` pinned at 0,
+  ``delta`` renamed to ``ttheta``).  ``hkl_soleil/APS POLAR`` and
+  ``hkl_soleil/PETRA3 P09 EH2`` join ``EULER_HORIZONTAL_GROUP`` in
+  their ``4-circles bissecting horizontal`` modes.  libhkl 5.1.3
+  exposes **no** vertical-bisecting mode for either six-circle
+  beamline geometry, so they participate only in the horizontal
+  group.  The two geometries also disagree on which native axis is
+  the bisecting primary: per the hklpy2 docs' ``writable`` column,
+  POLAR uses native ``mu`` (the renaming binds ``mu -> omega``) and
+  P09 EH2 uses native ``omega`` (identity primary).  Detector axes
+  also differ (POLAR: ``gamma``; P09 EH2: ``delta``).
+
+The dedicated CI workflow lives in :issue:`65`.
 
 Earlier issues now closed as not-a-bug after re-investigation:
 
@@ -153,6 +167,16 @@ EULER_VERTICAL_GROUP = {
         reals=["mu", "omega", "chi", "phi", "ttheta"],
         mode="bisecting_4c",
     ),
+    "sixc": dict(
+        solver="ad_hoc",
+        geometry="sixc",
+        # backend canonical: alpha, omega, chi, phi, delta, gamma
+        # rename: delta -> ttheta (detector); alpha and gamma are the
+        # 5-/6-circle add-ons pinned at 0 by ``bisecting_4c`` and are
+        # left under their backend names.
+        reals=["alpha", "omega", "chi", "phi", "ttheta", "gamma"],
+        mode="bisecting_4c",
+    ),
     "diffcalc": dict(
         solver="diffcalc",
         geometry="diffcalc_4S_2D",
@@ -198,6 +222,31 @@ EULER_HORIZONTAL_GROUP = {
         geometry="E6C",
         reals=["omega", "eta", "chi", "phi", "ttheta", "delta"],
         mode="bissector_horizontal",
+    ),
+    "aps_polar": dict(
+        solver="hkl_soleil",
+        geometry="APS POLAR",
+        # backend canonical: tau, mu, chi, phi, gamma, delta
+        # mode writables (per hklpy2 docs): mu, chi, phi, gamma
+        # rename: mu -> omega (primary sample axis), gamma -> ttheta
+        # (in-plane detector); tau and delta are pinned at 0 by the
+        # mode and kept under their backend names.
+        reals=["tau", "omega", "chi", "phi", "ttheta", "delta"],
+        mode="4-circles bissecting horizontal",
+    ),
+    "p09_eh2": dict(
+        solver="hkl_soleil",
+        geometry="PETRA3 P09 EH2",
+        # backend canonical: mu, omega, chi, phi, delta, gamma
+        # mode writables (per hklpy2 docs): omega, chi, phi, delta
+        # rename: omega -> omega (identity primary), delta -> ttheta
+        # (in-plane detector); mu and gamma are pinned at 0 by the
+        # mode and kept under their backend names.  Note: although
+        # ``APS POLAR`` was derived from this geometry, the two
+        # disagree on which native axis is the bisecting primary
+        # (POLAR: ``mu``; P09 EH2: ``omega``).
+        reals=["mu", "omega", "chi", "phi", "ttheta", "gamma"],
+        mode="4-circles bissecting horizontal",
     ),
     "fourch": dict(
         solver="ad_hoc",
@@ -337,6 +386,7 @@ KNOWN_TTH_DISAGREEMENTS = {
     ("euler_vertical", "fourcv", "triclinic", (0, 0, 6)): "issue #68",
     ("euler_vertical", "psic", "triclinic", (0, 0, 6)): "issue #68",
     ("euler_vertical", "fivec", "triclinic", (0, 0, 6)): "issue #68",
+    ("euler_vertical", "sixc", "triclinic", (0, 0, 6)): "issue #68",
     ("euler_vertical", "diffcalc", "triclinic", (0, 0, 6)): "issue #68",
     ("euler_horizontal", "fourch", "triclinic", (0, 0, 6)): "issue #68",
     ("euler_horizontal", "psic", "triclinic", (0, 0, 6)): "issue #68",


### PR DESCRIPTION
- closes #64
- refs #50

## Summary

PR4 of the cross-validation campaign (#50).  Adds three six-circle
bisecting peer entries that fit into the existing eulerian
vertical / horizontal groups (no new top-level group needed).

## Scope

Three new entries:

* **`ad_hoc/sixc bisecting_4c`** -> `EULER_VERTICAL_GROUP`
  (backend `delta` -> user `ttheta`; `alpha` / `gamma` pinned at 0).
* **`hkl_soleil/APS POLAR 4-circles bissecting horizontal`** ->
  `EULER_HORIZONTAL_GROUP` (backend `mu` -> user `omega`, backend
  `gamma` -> user `ttheta`; `tau` / `delta` pinned at 0).
* **`hkl_soleil/PETRA3 P09 EH2 4-circles bissecting horizontal`** ->
  `EULER_HORIZONTAL_GROUP` (backend `omega` identity, backend
  `delta` -> user `ttheta`; `mu` / `gamma` pinned at 0).

## Key findings

* **POLAR and P09 EH2 disagree on which native axis is the bisecting
  primary** despite the POLAR geometry being historically derived
  from P09.  Per the hklpy2 docs' `writable` column (auto-generated
  from the Hkl C source): POLAR uses `mu`, P09 EH2 uses `omega`.
  Detector axes also differ: POLAR `gamma`, P09 EH2 `delta`.
* **libhkl 5.1.3 exposes no vertical-bisecting mode for either
  six-circle beamline geometry**, so both participate only in the
  horizontal group.  POLAR has a `psi constant vertical` mode but
  it is not a bisecting equivalent.
* **`ad_hoc/sixc` triclinic (0,0,6) cross-solver case** added to
  `KNOWN_TTH_DISAGREEMENTS` (matches the existing
  `ad_hoc/diffcalc`-family pattern tracked in #68; ad_hoc/sixc
  returns 76.17°, hkl_soleil/E4CV returns 76.89°).

## Authority for the axis mappings

Cross-checked against three independent sources:

1. The hklpy2 documentation tables (`writable` column) at
   https://blueskyproject.io/hklpy2/diffractometers.html#solver-hkl-soleil-geometry-aps-polar
   and `...#solver-hkl-soleil-geometry-petra3-p09-eh2`.
2. Empirical probe: bootstrap a UB on each peer and call `forward()`
   for cubic (0,0,6) -- the axis carrying the rotation matches the
   docs' writable column in every case.
3. Bragg-law analytic check: `|2theta| = 117.99 deg` for cubic
   (0,0,6) at lambda = 1.0 A reproduced by both POLAR and P09 EH2.

## Test results (local)

* 42 new cases (21 round-trip + 21 cross-solver) from the three
  new entries.
* Round-trip: 21 / 21 PASS.
* Cross-solver vs. reference: 20 / 21 PASS + 1 XFAIL (the
  sixc triclinic (0,0,6) #68 case).
* Full suite: 473 passed, 22 xfailed, 4 xpassed (the xpasses are
  from `CI_ENV_DEPENDENT_GAPS`, which is intentionally
  `strict=False`).
* Coverage: 100% line and branch maintained.
* `pre-commit run --all-files`: clean.

Agent: OpenCode (claudeopus47)
