### PR TITLE
docs #86 correct ad_hoc and diffcalc guides for hklpy2 0.7.0 API

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -42,6 +42,7 @@ describe future plans.
     Fixes
     ~~~~~
 
+    * Correct ``ad_hoc`` and ``diffcalc`` guides to use current hklpy2 API.  :issue:`86`
     * Correct horizontal eulerian cross-validation reference to ``E4CH``.  :issue:`78`
     * Honour ``r1`` / ``r2`` arguments in ``AdHocSolver.calculate_UB``.  :issue:`56`
     * Honour ``r1`` / ``r2`` arguments in ``DiffcalcSolver.calculate_UB``.  :issue:`58`

--- a/docs/source/guide_ad_hoc.rst
+++ b/docs/source/guide_ad_hoc.rst
@@ -59,8 +59,8 @@ Set the crystal lattice
 
 .. code-block:: python
 
-   fourc.sample.lattice = hklpy2.SI_LATTICE_PARAMETERS
-   fourc.wavelength.set(1.0)
+   fourc.add_sample(name="silicon", a=hklpy2.SI_LATTICE_PARAMETER)
+   fourc.beam.wavelength.put(1.0)
 
 Add orientation reflections
 ---------------------------
@@ -74,13 +74,13 @@ Provide two reflections measured at known motor positions:
    theta = math.degrees(math.asin(1.0 / (2 * 5.431)))
    tth = 2 * theta
 
-   r1 = fourc.sample.add_reflection(
+   r1 = fourc.add_reflection(
        pseudos={"h": 1, "k": 0, "l": 0},
        reals={"omega": theta, "chi": 0, "phi": 0, "ttheta": tth},
        wavelength=1.0,
        name="r1",
    )
-   r2 = fourc.sample.add_reflection(
+   r2 = fourc.add_reflection(
        pseudos={"h": 0, "k": 1, "l": 0},
        reals={"omega": theta, "chi": 0, "phi": 90, "ttheta": tth},
        wavelength=1.0,
@@ -101,7 +101,7 @@ The default mode for ``fourcv`` is ``bisecting``.  To change it:
 
 .. code-block:: python
 
-   fourc.solver.mode = "fixed_phi"
+   fourc.core.mode = "fixed_phi"
 
 See :ref:`geometries.ad_hoc` for the full mode tables for each geometry.
 
@@ -119,10 +119,12 @@ Compute (h, k, l) from motor positions (inverse)
 
 .. code-block:: python
 
-   fourc.inverse()
+   fourc.inverse(fourc.real_position)
 
-This returns the current ``(h, k, l)`` values from the current motor
-positions.
+This returns the ``(h, k, l)`` values computed from the supplied
+motor positions.  ``fourc.real_position`` is the current readout of
+all real axes; pass a different set of values to compute ``(h, k, l)``
+at a hypothetical position instead.
 
 Available geometries at a glance
 ---------------------------------

--- a/docs/source/guide_diffcalc.rst
+++ b/docs/source/guide_diffcalc.rst
@@ -36,8 +36,8 @@ Set the crystal lattice
 
 .. code-block:: python
 
-   psic.sample.lattice = hklpy2.SI_LATTICE_PARAMETERS
-   psic.wavelength.set(1.54)
+   psic.add_sample(name="silicon", a=hklpy2.SI_LATTICE_PARAMETER)
+   psic.beam.wavelength.put(1.54)
 
 Add orientation reflections
 ---------------------------
@@ -74,7 +74,7 @@ bisector: ``eta = delta/2``, eta=0, nu=0).  To change it:
 
 .. code-block:: python
 
-   psic.solver.mode = "4S+2D eta_chi_phi_fixed"
+   psic.core.mode = "4S+2D mu_chi_phi_fixed"
 
 See :ref:`geometry.diffcalc_4S_2D` for the full list of 23 modes.
 
@@ -92,10 +92,12 @@ Compute (h, k, l) from motor positions (inverse)
 
 .. code-block:: python
 
-   psic.inverse()
+   psic.inverse(psic.real_position)
 
-This returns the current ``(h, k, l)`` values from the current motor
-positions.
+This returns the ``(h, k, l)`` values computed from the supplied
+motor positions.  ``psic.real_position`` is the current readout of
+all real axes; pass a different set of values to compute ``(h, k, l)``
+at a hypothetical position instead.
 
 Available geometries at a glance
 ---------------------------------


### PR DESCRIPTION
- closes #86

## Summary

Reported by @jwkim-anl while following the ``ad_hoc`` guide for
``psic``: ``fourc.sample.add_reflection(...)`` raises
``AttributeError`` because ``add_reflection`` is a diffractometer
method, not a sample method.  Investigating exposed five more
API-mismatch defects in the same two how-to guides; all are
fixed here.

## Changes (docs only)

* ``docs/source/guide_ad_hoc.rst`` and ``docs/source/guide_diffcalc.rst``:
  * ``SI_LATTICE_PARAMETERS`` -> ``SI_LATTICE_PARAMETER`` (singular).
  * ``sample.lattice = <scalar>`` -> ``add_sample(name=..., a=...)``.
  * ``<diff>.wavelength.set(x)`` -> ``<diff>.beam.wavelength.put(x)``.
  * ``<diff>.sample.add_reflection(...)`` -> ``<diff>.add_reflection(...)``.
  * ``<diff>.solver.mode = '...'`` -> ``<diff>.core.mode = '...'``.
  * ``<diff>.inverse()`` (no args) -> ``<diff>.inverse(<diff>.real_position)``.
  * Reword inverse() description for clarity (two short sentences).
* ``docs/source/guide_diffcalc.rst``: swap mode example to
  ``4S+2D mu_chi_phi_fixed`` so the example's ``forward(4,0,0)``
  returns a valid solution.  The original ``4S+2D eta_chi_phi_fixed``
  raises ``Sample orientation cannot be chosen uniquely`` on the
  bootstrap UB.

## Verification

* Each guide's code blocks were extracted in source order and
  executed top-down in a fresh Python process; both ran without
  exceptions.
* The YAML-placeholder block at the end of ``guide_ad_hoc.rst``
  (``register_geometry_file("/path/to/mybeamline.yml", ...)``)
  uses an illustrative placeholder filename and is necessarily
  skipped by the smoke runner.  Out of scope for this PR; smoke-
  test infrastructure for such blocks is tracked in #88.
* ``pre-commit run --all-files``: clean.
* ``pytest ./tests --cov``: 473 passed, 22 xfailed, 4 xpassed.
  Coverage 100% line and branch.

## Out of scope

* Forward()-returns-list wording: tracked in #87.
* Guide-regression smoke test in CI: tracked in #88.

Agent: OpenCode (claudeopus47)
