### PR TITLE
docs #87 clarify forward() returns a single chosen solution

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -42,6 +42,7 @@ describe future plans.
     Fixes
     ~~~~~
 
+    * Clarify guide wording: diffractometer ``forward()`` returns a single chosen solution.  :issue:`87`
     * Correct ``ad_hoc`` and ``diffcalc`` guides to use current hklpy2 API.  :issue:`86`
     * Correct horizontal eulerian cross-validation reference to ``E4CH``.  :issue:`78`
     * Honour ``r1`` / ``r2`` arguments in ``AdHocSolver.calculate_UB``.  :issue:`56`

--- a/docs/source/guide_ad_hoc.rst
+++ b/docs/source/guide_ad_hoc.rst
@@ -112,7 +112,24 @@ Compute motor positions (forward)
 
    fourc.forward(1, 0, 0)
 
-This returns a list of motor-position solutions for the given ``(h, k, l)``.
+This returns a single chosen motor-position solution for the given
+``(h, k, l)`` (an ``Hklpy2DiffractometerRealPos``).  The underlying
+solver's ``forward()`` may return multiple solutions; the
+diffractometer picks one according to the policy assigned to
+``fourc._forward_solution`` (defaults to
+:func:`hklpy2.utils.pick_first_solution`).  The complete list of
+solutions can be returned from ``fourc.core.forward((1, 0, 0))``.
+See the upstream hklpy2 guide `How to Choose the Default forward()
+Solution
+<https://blueskyproject.io/hklpy2/guides/how_forward_solution.html>`_
+for details.
+
+.. tip::
+
+   The two call shapes differ: ``fourc.forward(1, 0, 0)`` takes
+   ``h``, ``k``, ``l`` as separate positional arguments, while
+   ``fourc.core.forward((1, 0, 0))`` takes a **single** sequence
+   (tuple / list / ndarray) or dict (e.g. ``{"h": 1, "k": 0, "l": 0}``).
 
 Compute (h, k, l) from motor positions (inverse)
 -------------------------------------------------

--- a/docs/source/guide_diffcalc.rst
+++ b/docs/source/guide_diffcalc.rst
@@ -85,7 +85,24 @@ Compute motor positions (forward)
 
    psic.forward(4, 0, 0)
 
-This returns a list of motor-position solutions for the given ``(h, k, l)``.
+This returns a single chosen motor-position solution for the given
+``(h, k, l)`` (an ``Hklpy2DiffractometerRealPos``).  The underlying
+solver's ``forward()`` may return multiple solutions; the
+diffractometer picks one according to the policy assigned to
+``psic._forward_solution`` (defaults to
+:func:`hklpy2.utils.pick_first_solution`).  The complete list of
+solutions can be returned from ``psic.core.forward((4, 0, 0))``.
+See the upstream hklpy2 guide `How to Choose the Default forward()
+Solution
+<https://blueskyproject.io/hklpy2/guides/how_forward_solution.html>`_
+for details.
+
+.. tip::
+
+   The two call shapes differ: ``psic.forward(4, 0, 0)`` takes
+   ``h``, ``k``, ``l`` as separate positional arguments, while
+   ``psic.core.forward((4, 0, 0))`` takes a **single** sequence
+   (tuple / list / ndarray) or dict (e.g. ``{"h": 4, "k": 0, "l": 0}``).
 
 Compute (h, k, l) from motor positions (inverse)
 -------------------------------------------------


### PR DESCRIPTION
- closes #87
- refs #86

## Summary

Both how-to guides previously said diffractometer ``forward()``
"returns a list of motor-position solutions".  That was inaccurate:
the diffractometer-level ``<diff>.forward(h, k, l)`` returns a
**single chosen** ``Hklpy2DiffractometerRealPos``.  The solver's
``forward()`` does return a list (per the
:class:`hklpy2.backends.base.SolverBase` contract); the
diffractometer's ``_forward_solution`` policy picks one from that
list.  See the issue comment from @prjemian for the upstream
solver contract reference.

## Changes (docs only)

Both ``docs/source/guide_ad_hoc.rst`` and
``docs/source/guide_diffcalc.rst``:

* Reword the "Compute motor positions (forward)" section to:
  * State that ``<diff>.forward(h, k, l)`` returns a single chosen
    ``Hklpy2DiffractometerRealPos``.
  * Name the picker policy
    (``<diff>._forward_solution``, default
    :func:`hklpy2.utils.pick_first_solution`).
  * Show how to get every candidate solution via
    ``<diff>.core.forward((h, k, l))``.
  * Link to the upstream "How to Choose the Default forward()
    Solution" guide.
* Add a ``.. tip::`` admonition flagging the call-shape asymmetry
  (``<diff>.forward`` takes separate positional ``h, k, l``;
  ``<diff>.core.forward`` takes a single sequence-or-dict
  argument).  This bit caught both reviewer and agent during the
  rewrite.

## Verification

* Both guides' code blocks were extracted in source order and
  executed top-down in a fresh Python process; both ran without
  exceptions (9 runnable blocks in ``guide_ad_hoc.rst``, 7 in
  ``guide_diffcalc.rst``; YAML-placeholder block legitimately
  skipped per #88).
* ``pre-commit run --all-files``: clean.
* ``pytest ./tests --cov``: 473 passed, 22 xfailed, 4 xpassed.
  Coverage 100% line and branch.

## Out of scope

* Smoke-test infrastructure to catch future API drift in guides:
  tracked in #88.

Agent: OpenCode (claudeopus47)
