### PR TITLE
fix #81 accept scalar default n_hat in AdHocSolver extras setter

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -47,6 +47,7 @@ describe future plans.
     Fixes
     ~~~~~
 
+    * Accept scalar default ``n_hat`` from ``hklpy2`` Core in ``AdHocSolver`` extras setter.  :issue:`81`
     * Clarify guide wording: diffractometer ``forward()`` returns a single chosen solution.  :issue:`87`
     * Correct ``ad_hoc`` and ``diffcalc`` guides to use current hklpy2 API.  :issue:`86`
     * Correct horizontal eulerian cross-validation reference to ``E4CH``.  :issue:`78`

--- a/src/hklpy2_solvers/ad_hoc_solver.py
+++ b/src/hklpy2_solvers/ad_hoc_solver.py
@@ -299,13 +299,20 @@ class AdHocSolver(SolverBase):
         if mode_obj is None:  # pragma: no cover - mode setter guarantees object
             return
 
-        # Surface-normal vector.
+        # Surface-normal vector.  ``hklpy2.Core`` defaults vector extras
+        # to the scalar ``0`` during ``update_solver()`` (see
+        # :issue:`81`); treat any non-iterable value as "unset" so the
+        # adapter can be constructed via ``hklpy2.creator`` for modes
+        # that expose ``n_hat`` (e.g. ``zaxis``).
         if "n_hat" in values:
             v = values["n_hat"]
             if v is None:
                 self._geom.surface_normal = None
             else:
-                self._geom.surface_normal = tuple(float(x) for x in v)
+                try:
+                    self._geom.surface_normal = tuple(float(x) for x in v)
+                except TypeError:
+                    self._geom.surface_normal = None
 
         # Reference-constraint scalar (psi / alpha_i / beta_out).
         rc = getattr(mode_obj, "reference_constraint", None)

--- a/tests/test_ad_hoc_solver.py
+++ b/tests/test_ad_hoc_solver.py
@@ -1760,3 +1760,106 @@ def test_ub_setter_default_lattice(parms, context):
     with context:
         solver.UB = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
         assert solver._geom.sample.lattice is not None
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for issue #81: scalar default extras from hklpy2 Core
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(
+                geometry="fourcv",
+                mode="fixed_psi",
+                values={"n_hat": 0},
+                expected_normal=None,
+            ),
+            does_not_raise(),
+            id="scalar 0 n_hat is normalised to None",
+        ),
+        pytest.param(
+            dict(
+                geometry="psic",
+                mode="fixed_alpha_i_vertical",
+                values={"n_hat": 0, "alpha_i": 0, "beta_out": 0},
+                expected_normal=None,
+            ),
+            does_not_raise(),
+            id="full scalar-default extras dict (Core push) accepted",
+        ),
+        pytest.param(
+            dict(
+                geometry="fourcv",
+                mode="fixed_psi",
+                values={"n_hat": (1, 0, 0)},
+                expected_normal=(1.0, 0.0, 0.0),
+            ),
+            does_not_raise(),
+            id="3-iterable n_hat still works after fix",
+        ),
+        pytest.param(
+            dict(
+                geometry="fourcv",
+                mode="fixed_psi",
+                values={"n_hat": None},
+                expected_normal=None,
+            ),
+            does_not_raise(),
+            id="None n_hat still clears surface_normal after fix",
+        ),
+    ],
+)
+def test_extras_n_hat_scalar_default(parms, context):
+    """``extras`` setter tolerates scalar ``n_hat`` from ``hklpy2.Core``.
+
+    Regression for :issue:`81`: ``hklpy2.ops.Core.update_solver()``
+    initialises every vector extra to scalar ``0`` (the module-level
+    ``DEFAULT_EXTRA_VALUE``).  The previous implementation iterated
+    ``n_hat`` unconditionally and raised ``TypeError`` for any
+    non-iterable input, breaking ``hklpy2.creator(solver='ad_hoc',
+    geometry='zaxis')``.  The fix normalises any non-iterable
+    ``n_hat`` value to ``None`` (treated as "no surface normal set").
+    """
+    with context:
+        solver = AdHocSolver(parms["geometry"])
+        solver.mode = parms["mode"]
+        solver.extras = parms["values"]
+        assert solver._geom.surface_normal == parms["expected_normal"]
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(geometry="zaxis"),
+            does_not_raise(),
+            id="hklpy2.creator builds ad_hoc/zaxis (default mode exposes n_hat)",
+        ),
+        pytest.param(
+            dict(geometry="s2d2"),
+            does_not_raise(),
+            id="hklpy2.creator builds ad_hoc/s2d2",
+        ),
+        pytest.param(
+            dict(geometry="fourcv"),
+            does_not_raise(),
+            id="hklpy2.creator builds ad_hoc/fourcv (no n_hat in default mode)",
+        ),
+    ],
+)
+def test_creator_end_to_end(parms, context):
+    """End-to-end smoke: ``hklpy2.creator`` instantiation for ad_hoc.
+
+    Regression for :issue:`81` (the ``zaxis`` case) and a guard that
+    the fix does not regress geometries whose default mode does not
+    expose ``n_hat``.
+    """
+    import hklpy2
+
+    with context:
+        sim = hklpy2.creator(solver="ad_hoc", geometry=parms["geometry"])
+        assert sim.core.solver.name == "ad_hoc"
+        assert sim.core.solver.geometry == parms["geometry"]


### PR DESCRIPTION
- closes #81
- #50 (unblocks future z-axis cross-validation work)

## Problem

`hklpy2.creator(solver="ad_hoc", geometry="zaxis")` raised
`TypeError: 'int' object is not iterable` because
`hklpy2.ops.Core.update_solver()` initialises every vector extra to
the scalar `DEFAULT_EXTRA_VALUE` (`0`), and `AdHocSolver.extras`
iterated `n_hat` unconditionally.

The PR1–PR3b cross-validation groups never tripped this because their
modes do not expose `n_hat`; PR4 (z-axis) does, which is how the bug
surfaced.

## Fix

Wrap the `n_hat` iteration in `try/except TypeError` and normalise
any non-iterable value to `None` (semantically "no surface normal
set").  Other vector-like extras (`psi`, `alpha_i`, `beta_out`,
`h2`, `k2`, `l2`) are already `float()`-cast and accept scalar
`0` without change — verified empirically before settling on the
minimal patch.

## Tests

Two new parametrized test functions in `tests/test_ad_hoc_solver.py`
(7 cases total), following the mandatory `parms, context` pattern:

* `test_extras_n_hat_scalar_default` — 4 cases: scalar `0`, full
  Core-style dict (`{n_hat: 0, alpha_i: 0, beta_out: 0}`), 3-iterable
  still works, `None` still works.
* `test_creator_end_to_end` — 3 cases: `hklpy2.creator` for `zaxis`
  (the original reproducer), `s2d2`, and `fourcv` (regression guard
  that the fix does not affect geometries without `n_hat`).

## Verification

* Original reproducer succeeds.
* Full test suite: 483 passed, 22 xfailed, 4 xpassed.
* Coverage: 100.000% (`ad_hoc_solver.py` 282/282 stmts, 92/92 branches).
* `pre-commit run --all-files`: clean.

## Release notes

One-line entry added to the unreleased `Fixes` subsection of
`RELEASE_NOTES.rst`, alphabetised.

Agent: OpenCode (claudeopus47)