### PR TITLE
fix #83 pin python=3.14 in cross-validation workflow

### DIFF
--- a/.github/workflows/cross-validation.yml
+++ b/.github/workflows/cross-validation.yml
@@ -58,12 +58,13 @@ jobs:
           environment-name: cross-validation
           # ``python=3.14`` pins the workflow to the same interpreter
           # series as the maintainer's local conda env (see
-          # :issue:`83`).  The three ``kappa_horizontal`` triclinic
-          # cases that previously failed only on CI track down to
-          # a Python-version sensitivity in the K6C bootstrap
-          # recipe: identical ``hkl``, ``hklpy2``, and
-          # ``ad-hoc-diffractometer`` versions; only Python differs
-          # (3.12 on CI vs 3.14 local).
+          # :issue:`83`).  Bringing CI to the same Python series
+          # eliminates one variable from the K6C ``bissector_horizontal``
+          # triclinic xfail diagnosis: with this pin CI and local
+          # match on Python, ``hkl``, ``hklpy2``, and
+          # ``ad-hoc-diffractometer``; only ``numpy`` still differs
+          # by a patch level (CI 2.4.5 vs local 2.4.4).  The xfails
+          # in ``CI_ENV_DEPENDENT_GAPS`` remain in place.
           create-args: >-
             python=3.14
             hklpy2

--- a/.github/workflows/cross-validation.yml
+++ b/.github/workflows/cross-validation.yml
@@ -56,8 +56,16 @@ jobs:
         uses: mamba-org/setup-micromamba@v3
         with:
           environment-name: cross-validation
+          # ``python=3.14`` pins the workflow to the same interpreter
+          # series as the maintainer's local conda env (see
+          # :issue:`83`).  The three ``kappa_horizontal`` triclinic
+          # cases that previously failed only on CI track down to
+          # a Python-version sensitivity in the K6C bootstrap
+          # recipe: identical ``hkl``, ``hklpy2``, and
+          # ``ad-hoc-diffractometer`` versions; only Python differs
+          # (3.12 on CI vs 3.14 local).
           create-args: >-
-            python=3.12
+            python=3.14
             hklpy2
             ad-hoc-diffractometer
             numpy
@@ -83,6 +91,15 @@ jobs:
         run: |
           micromamba list -n cross-validation || true
           pip list
+
+      - name: Key package versions (issue #83 diagnostic)
+        # Focused summary of the packages that drive cross-validation
+        # behaviour; full lists above are kept for forensics.
+        run: |
+          python --version
+          micromamba list -n cross-validation 2>/dev/null \
+            | awk '$1 ~ /^(hkl|hklpy2|ad-hoc-diffractometer|numpy|diffcalc-core|gobject-introspection)$/ \
+                   {printf "  %-30s %s\n", $1, $2}'
 
       - name: Confirm libhkl loads via gobject-introspection
         run: |

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -53,12 +53,12 @@ describe future plans.
     * Correct horizontal eulerian cross-validation reference to ``E4CH``.  :issue:`78`
     * Honour ``r1`` / ``r2`` arguments in ``AdHocSolver.calculate_UB``.  :issue:`56`
     * Honour ``r1`` / ``r2`` arguments in ``DiffcalcSolver.calculate_UB``.  :issue:`58`
-    * Pin ``python=3.14`` in ``cross-validation.yml`` to remove K6C triclinic version skew.  :issue:`83`
+    * Pin ``python=3.14`` in ``cross-validation.yml`` to narrow K6C triclinic env skew.  :issue:`83`
 
     Maintenance
     ~~~~~~~~~~~
 
-    * Drop ``CI_ENV_DEPENDENT_GAPS`` xfails for K6C triclinic cross-validation cases.  :issue:`83`
+    * Add focused key-package-version diagnostic step to ``cross-validation.yml``.  :issue:`83`
     * Remove cross-references between solver implementations.  :issue:`60`
 
 0.3.1

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -53,10 +53,12 @@ describe future plans.
     * Correct horizontal eulerian cross-validation reference to ``E4CH``.  :issue:`78`
     * Honour ``r1`` / ``r2`` arguments in ``AdHocSolver.calculate_UB``.  :issue:`56`
     * Honour ``r1`` / ``r2`` arguments in ``DiffcalcSolver.calculate_UB``.  :issue:`58`
+    * Pin ``python=3.14`` in ``cross-validation.yml`` to remove K6C triclinic version skew.  :issue:`83`
 
     Maintenance
     ~~~~~~~~~~~
 
+    * Drop ``CI_ENV_DEPENDENT_GAPS`` xfails for K6C triclinic cross-validation cases.  :issue:`83`
     * Remove cross-references between solver implementations.  :issue:`60`
 
 0.3.1

--- a/tests/test_cross_validation.py
+++ b/tests/test_cross_validation.py
@@ -413,11 +413,26 @@ KNOWN_FORWARD_GAPS = {
 }
 
 # CI-environment-dependent forward gaps: cases that pass locally on
-# the maintainer's conda env but fail on a mismatched CI env.  Empty
-# now that ``cross-validation.yml`` pins the same Python series as
-# the maintainer's local env (see :issue:`83`); kept as a documented
-# extension point if a future version-skew regression surfaces.
-CI_ENV_DEPENDENT_GAPS: dict[tuple[str, str, str, tuple[int, int, int]], str] = {}
+# the maintainer's conda env but fail on the conda-forge env used by
+# the dedicated ``cross-validation.yml`` workflow.  Marked
+# ``xfail(strict=False)`` so the case xfails when it fails (CI) and
+# passes silently when it passes (local) - distinct from the
+# strict-xfails in ``KNOWN_FORWARD_GAPS`` because the failure mode
+# depends on the package-version stack, not on the suite's own
+# logic.  Investigation tracked in the issue listed for each case.
+#
+# Note: a side-by-side env comparison (see :issue:`83` history) shows
+# CI and local now match on Python, hkl, hklpy2, and
+# ad-hoc-diffractometer; only ``numpy`` differs by a patch level
+# (CI 2.4.5 vs local 2.4.4).  The K6C ``bissector_horizontal``
+# triclinic bootstrap is suspected to be sensitive at that level
+# (BLAS / LAPACK build differences via numpy wheels).
+CI_ENV_DEPENDENT_GAPS = {
+    # https://github.com/prjemian/hklpy2_solvers/issues/83
+    ("kappa_horizontal", "k6c", "triclinic", (0, 0, 6)): "issue #83",
+    ("kappa_horizontal", "k6c", "triclinic", (1, 1, 0)): "issue #83",
+    ("kappa_horizontal", "kappa4ch", "triclinic", (1, 1, 0)): "issue #83",
+}
 
 # Per-axis angle comparisons across solvers are deferred: bisecting-mode
 # branch selection (libhkl picks ``omega ~ 180 - omega`` relative to
@@ -756,11 +771,11 @@ def _make_param(group_name, entry, sample, hkl, *, apply_tth_xfail=False):
       this peer for this reflection; tracked in its own issue), so
       both round-trip and cross-solver tests must strict-xfail.
     * ``CI_ENV_DEPENDENT_GAPS`` applies when the case is known to
-      fail only under specific package-version stacks.  Non-strict so
+      fail only under specific package-version stacks (e.g.
+      conda-forge libhkl / numpy patch differences).  Non-strict so
       the case xfails when it fails and passes silently when it
       passes - the suite tolerates both behaviours until the
-      underlying version-sensitivity is resolved.  Currently empty;
-      retained as a documented extension point.
+      underlying version-sensitivity is resolved.
     * ``KNOWN_TTH_DISAGREEMENTS`` applies only when ``apply_tth_xfail``
       is True (cross-solver comparison only; round-trip still passes).
     """

--- a/tests/test_cross_validation.py
+++ b/tests/test_cross_validation.py
@@ -413,19 +413,11 @@ KNOWN_FORWARD_GAPS = {
 }
 
 # CI-environment-dependent forward gaps: cases that pass locally on
-# the maintainer's conda env but fail on the conda-forge env used by
-# the dedicated ``cross-validation.yml`` workflow.  Marked
-# ``xfail(strict=False)`` so the case xfails when it fails (CI) and
-# passes silently when it passes (local) - distinct from the
-# strict-xfails in ``KNOWN_FORWARD_GAPS`` because the failure mode
-# depends on the package-version stack, not on the suite's own
-# logic.  Investigation tracked in the issue listed for each case.
-CI_ENV_DEPENDENT_GAPS = {
-    # https://github.com/prjemian/hklpy2_solvers/issues/83
-    ("kappa_horizontal", "k6c", "triclinic", (0, 0, 6)): "issue #83",
-    ("kappa_horizontal", "k6c", "triclinic", (1, 1, 0)): "issue #83",
-    ("kappa_horizontal", "kappa4ch", "triclinic", (1, 1, 0)): "issue #83",
-}
+# the maintainer's conda env but fail on a mismatched CI env.  Empty
+# now that ``cross-validation.yml`` pins the same Python series as
+# the maintainer's local env (see :issue:`83`); kept as a documented
+# extension point if a future version-skew regression surfaces.
+CI_ENV_DEPENDENT_GAPS: dict[tuple[str, str, str, tuple[int, int, int]], str] = {}
 
 # Per-axis angle comparisons across solvers are deferred: bisecting-mode
 # branch selection (libhkl picks ``omega ~ 180 - omega`` relative to
@@ -764,11 +756,11 @@ def _make_param(group_name, entry, sample, hkl, *, apply_tth_xfail=False):
       this peer for this reflection; tracked in its own issue), so
       both round-trip and cross-solver tests must strict-xfail.
     * ``CI_ENV_DEPENDENT_GAPS`` applies when the case is known to
-      fail only under specific package-version stacks (e.g.
-      conda-forge libhkl).  Non-strict so the case xfails when it
-      fails and passes silently when it passes - the suite tolerates
-      both behaviours until the underlying version-sensitivity is
-      resolved.
+      fail only under specific package-version stacks.  Non-strict so
+      the case xfails when it fails and passes silently when it
+      passes - the suite tolerates both behaviours until the
+      underlying version-sensitivity is resolved.  Currently empty;
+      retained as a documented extension point.
     * ``KNOWN_TTH_DISAGREEMENTS`` applies only when ``apply_tth_xfail``
       is True (cross-solver comparison only; round-trip still passes).
     """


### PR DESCRIPTION
- #83 (partial mitigation; numpy bisect deferred — see issue comment)
- #50 (cross-validation umbrella)

## Diagnosis (updated after first CI run)

Initial hypothesis (Python-version sensitivity) was wrong.  CI run on
this PR with `python=3.14` reproduced all 3 K6C
`bissector_horizontal` triclinic failures.  Side-by-side env after
the pin:

| package | CI | local |
|---|---|---|
| python | 3.14.4 | 3.14.4 |
| hkl | 5.1.3.3561 | 5.1.3.3561 |
| hklpy2 | 0.7.0 | 0.7.0 |
| ad-hoc-diffractometer | 0.10.1 | 0.10.1 |
| diffcalc-core | 0.4.0 | 0.4.0 |
| **numpy** | **2.4.5** | **2.4.4** |

Only `numpy` differs (patch-level).  K6C `bissector_horizontal`
triclinic bootstrap is suspected to be sensitive at the BLAS/LAPACK
boundary that numpy wheels expose differently across patches.

## What this PR does

* Pin `python=3.14` in `.github/workflows/cross-validation.yml` —
  narrows the diagnostic envelope to a single remaining variable
  (numpy patch level).
* Add `Key package versions` diagnostic step (addresses issue task
  #1 — capture exact CI versions in a focused, scannable form).
* Keep `CI_ENV_DEPENDENT_GAPS` xfails in place so the workflow is
  green.

## What this PR does NOT do (deferred follow-up on #83)

* Bisect numpy 2.4.4 vs 2.4.5 (issue task #3).
* Pin numpy or harden the bootstrap recipe (issue task #4).

The issue stays open for that follow-up work.  See the issue
comment for the full status update.

## Verification

* Cross-validation workflow: **green** on this branch (245 passed,
  22 xfailed, 3 xfailed via `CI_ENV_DEPENDENT_GAPS`).
* Default CI matrix (Python 3.10–3.14): all green.
* Local suite: 483 passed, 22 xfailed, 4 xpassed (the 4 xpasses
  are the `strict=False` cases that pass on the maintainer env).
* Coverage: 100.000% maintained.
* `pre-commit run --all-files`: clean.

Agent: OpenCode (claudeopus47)