### PR TITLE
test #71 document psic bisecting_horizontal asymmetric-reflection gap

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -43,6 +43,7 @@ describe future plans.
     ~~~~~~~~~~~~
 
     * Add guide-regression smoke test to catch API drift in how-to guides.  :issue:`88`
+    * Add regression test documenting ``ad_hoc/psic bisecting_horizontal`` asymmetric-reflection gap.  :issue:`71`
 
     Fixes
     ~~~~~

--- a/tests/test_cross_validation.py
+++ b/tests/test_cross_validation.py
@@ -403,7 +403,12 @@ KNOWN_TTH_DISAGREEMENTS = {
 # the cross-solver comparison tests so the gap is documented in code
 # and a future fix surfaces as ``XPASS``.
 KNOWN_FORWARD_GAPS = {
-    # https://github.com/prjemian/hklpy2_solvers/issues/71
+    # https://github.com/prjemian/hklpy2_solvers/issues/71 and upstream
+    # https://github.com/BCDA-APS/ad_hoc_diffractometer/issues/275 -
+    # ``psic bisecting_horizontal`` returns zero solutions for the
+    # asymmetric sapphire reflection ``(0, 1, 2)``; the broader
+    # asymmetric-reflection pattern is exercised by the dedicated
+    # test ``test_psic_bisecting_horizontal_asymmetric_pattern``.
     ("euler_horizontal", "psic", "sapphire", (0, 1, 2)): "issue #71",
     # https://github.com/prjemian/hklpy2_solvers/issues/77
     ("kappa_horizontal", "kappa6c", "cubic", (1, 1, 0)): "issue #77",
@@ -930,3 +935,98 @@ def test_two_theta_matches_reference(parms, context, simulators):
             f"ref={ref_tth:.6f}, peer={peer_tth:.6f}, "
             f"diff={abs(peer_tth - ref_tth):.6f} deg"
         )
+
+
+# ---------------------------------------------------------------------------
+# Issue #71 broader-pattern regression
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(hkl=(0, 0, 3)),
+            does_not_raise(),
+            id="symmetric-003-solves",
+        ),
+        pytest.param(
+            dict(hkl=(0, 0, 6)),
+            does_not_raise(),
+            id="symmetric-006-solves",
+        ),
+        pytest.param(
+            dict(hkl=(1, 1, 0)),
+            does_not_raise(),
+            id="symmetric-110-solves",
+        ),
+        pytest.param(
+            dict(hkl=(1, 1, 3)),
+            does_not_raise(),
+            id="symmetric-113-solves",
+        ),
+        pytest.param(
+            dict(hkl=(1, 1, 6)),
+            does_not_raise(),
+            id="symmetric-116-solves",
+        ),
+        pytest.param(
+            dict(hkl=(0, 1, 1)),
+            pytest.raises(NoForwardSolutions),
+            id="asymmetric-011-known-gap",
+        ),
+        pytest.param(
+            dict(hkl=(0, 1, 2)),
+            pytest.raises(NoForwardSolutions),
+            id="asymmetric-012-known-gap",
+        ),
+        pytest.param(
+            dict(hkl=(0, 2, 1)),
+            pytest.raises(NoForwardSolutions),
+            id="asymmetric-021-known-gap",
+        ),
+        pytest.param(
+            dict(hkl=(1, 0, 1)),
+            pytest.raises(NoForwardSolutions),
+            id="asymmetric-101-known-gap",
+        ),
+        pytest.param(
+            dict(hkl=(1, 0, 2)),
+            pytest.raises(NoForwardSolutions),
+            id="asymmetric-102-known-gap",
+        ),
+        pytest.param(
+            dict(hkl=(1, 0, 4)),
+            pytest.raises(NoForwardSolutions),
+            id="asymmetric-104-known-gap",
+        ),
+    ],
+)
+def test_psic_bisecting_horizontal_asymmetric_pattern(parms, context, simulators):
+    """Document the ``ad_hoc/psic bisecting_horizontal`` asymmetric-reflection gap.
+
+    Regression for :issue:`71` (and upstream
+    ``BCDA-APS/ad_hoc_diffractometer#275``): the
+    ``bisecting_horizontal`` mode on ``ad_hoc/psic`` cannot solve
+    sapphire reflections whose Miller indices have ``h`` or ``k``
+    nonzero with ``h != k``, while the three peers in
+    ``EULER_HORIZONTAL_GROUP`` (``hkl_soleil/E6C``,
+    ``ad_hoc/fourch``, ``diffcalc/diffcalc_4S_2D``) solve every
+    reflection in this scan to within ``0.001 deg``.
+
+    The ``context`` parameter encodes the expected behaviour:
+    symmetric reflections (``(0, 0, l)`` and ``(h, h, l)``) must
+    forward successfully (``does_not_raise()``); asymmetric ones
+    (``h`` or ``k`` nonzero, ``h != k``) must raise
+    :class:`hklpy2.exceptions.NoForwardSolutions`.
+
+    When the upstream fix lands, the asymmetric cases will return
+    solutions instead of raising and this test will surface those
+    as ``DID NOT RAISE`` failures — the intended signal to remove
+    the asymmetric cases (and the ``(0, 1, 2)`` entry from
+    ``KNOWN_FORWARD_GAPS``) and promote them to the cross-validation
+    matrix proper.
+    """
+    with context:
+        sim = simulators[("euler_horizontal", "psic", "sapphire")]
+        sim.forward(*parms["hkl"])


### PR DESCRIPTION
- closes #71
- #50 (cross-validation umbrella)

## Background

`ad_hoc/psic bisecting_horizontal` returns zero solutions for sapphire
reflections whose Miller indices have `h` or `k` nonzero with
`h != k`.  The three peers in `EULER_HORIZONTAL_GROUP`
(`hkl_soleil/E6C`, `ad_hoc/fourch`, `diffcalc/diffcalc_4S_2D`)
solve the same reflections to within `0.001 deg`.

Empirical pattern (sapphire @ lambda=1 A):

| hkl       | peers       | psic                 |
|-----------|-------------|----------------------|
| (0, 0, 3) | 13.261      | 13.261               |
| (0, 0, 6) | 26.704      | 26.704               |
| (1, 1, 0) | 24.265      | 24.265               |
| (1, 1, 3) | 27.750      | 27.750               |
| (1, 1, 6) | 36.390      | 36.390               |
| (0, 1, 1) | (3 solve)   | **NoForwardSolutions** |
| (0, 1, 2) | 16.524      | **NoForwardSolutions** |
| (0, 2, 1) | (3 solve)   | **NoForwardSolutions** |
| (1, 0, 1) | 14.627      | **NoForwardSolutions** |
| (1, 0, 2) | (3 solve)   | **NoForwardSolutions** |
| (1, 0, 4) | 22.609      | **NoForwardSolutions** |

Mode constraints: `BisectConstraint('mu', 'nu')`,
`SampleConstraint('eta', 0.0)`, `DetectorConstraint('delta', 0.0)`.
The writable submanifold (`chi`, `phi`, `nu`) cannot reach Q
vectors with the required out-of-(h,h,l)-plane component.

## Root cause is upstream

Filed **BCDA-APS/ad_hoc_diffractometer#275** with a minimal
reproducer, the broader 6-reflection failure scan, and a hypothesis
pointing at the over-constraining ConstraintSet.  The actual code
fix lives in `ad_hoc_diffractometer`'s mode definition, not in
this repo.

## What this PR does

* Adds dedicated parametrized test
  `test_psic_bisecting_horizontal_asymmetric_pattern` with **11
  cases**:
  - **5 symmetric** (`(0,0,3)`, `(0,0,6)`, `(1,1,0)`, `(1,1,3)`,
    `(1,1,6)`) under `does_not_raise()`.
  - **6 asymmetric** (`(0,1,1)`, `(0,1,2)`, `(0,2,1)`, `(1,0,1)`,
    `(1,0,2)`, `(1,0,4)`) under `pytest.raises(NoForwardSolutions)`.
* Follows the mandatory project test style (parametrized,
  `parms, context`, expected behaviour encoded in `context`).
* Comment on `KNOWN_FORWARD_GAPS` updated to cross-link upstream
  #275 and point at the new dedicated test.
* Release notes: one Enhancement entry.

## Why a dedicated test rather than expanding the matrix

Adding `(1, 0, 1)` to `EXTRA_REFLECTIONS_BY_SAMPLE["sapphire"]`
would trigger **5 unrelated failures** on other groups
(`kappa_vertical/kappa4cv`, `kappa_horizontal/k6c`,
`kappa_horizontal/kappa4ch`, `kappa_horizontal/kappa6c`) that are
likely distinct ad_hoc bugs deserving their own issues, not silent
regressions on this PR.  The dedicated test keeps #71's scope clean.

## Future signal (after upstream lands)

When the upstream fix ships in a new `ad_hoc_diffractometer` release:

* 6 asymmetric parameter sets in the new test → `DID NOT RAISE`
  hard failures.
* `(euler_horizontal, psic, sapphire, (0, 1, 2))` xfail in
  `KNOWN_FORWARD_GAPS` → `XPASS` hard failure (strict=True), on
  both `test_forward_inverse_roundtrip` and
  `test_two_theta_matches_reference`.

Eight loud failures will surface on the next CI run after the
version bump.  A new issue will track the mechanical cleanup:
remove the strict-raise expectations, drop the `KNOWN_FORWARD_GAPS`
entry, and promote `(1, 0, 1)` (and any other fixed asymmetric
reflections) into `EXTRA_REFLECTIONS_BY_SAMPLE`.

## Verification

* Full local suite: **494 passed**, 22 xfailed, 4 xpassed
  (was 483p / 22xf / 4xp; the 11 new tests are all PASS).
* Coverage: **100.000%** maintained.
* `pre-commit run --all-files`: clean.

Agent: OpenCode (claudeopus47)