### PR TITLE
test #69 expand cross-validation sample set to 7 crystal systems

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -38,6 +38,7 @@ describe future plans.
     * Add six-circle bisecting peers to cross-validation groups.  :issue:`64`
     * Add vertical four-circle cross-validation suite against ``hkl_soleil``.  :issue:`50`
     * Add vertical kappa four-circle cross-validation group against ``hkl_soleil``.  :issue:`66`
+    * Expand cross-validation sample set to all seven crystal systems.  :issue:`69`
 
     Enhancements
     ~~~~~~~~~~~~
@@ -59,7 +60,9 @@ describe future plans.
     * Honour ``r1`` / ``r2`` arguments in ``DiffcalcSolver.calculate_UB``.  :issue:`58`
     * Lift ``ad_hoc`` ``psic`` / ``kappa6c`` ``bisecting_horizontal`` known-gap markers.  :issue:`99`
     * Pin ``python=3.14`` in ``cross-validation.yml`` to narrow K6C triclinic env skew.  :issue:`83`
+    * Track ``ad_hoc`` horizontal-bisecting rhombohedral ``(1, 1, 0)`` gap as known-gap.  :issue:`69`
     * Track ``ad_hoc`` kappa-vertical sapphire ``(0, 1, 2)`` regression as new known-gap.  :issue:`99`
+    * Track libhkl rhombohedral ``(0, 0, 6)`` B-matrix disagreements as ``tth``-disagreement.  :issue:`68`
 
     Maintenance
     ~~~~~~~~~~~

--- a/tests/test_cross_validation.py
+++ b/tests/test_cross_validation.py
@@ -100,8 +100,35 @@ pytestmark = pytest.mark.cross_validation
 # ---------------------------------------------------------------------------
 
 SAMPLES = {
+    # cubic — single-parameter, alpha = beta = gamma = 90 deg
     "cubic": dict(name="cubic", a=3.5),
+    # tetragonal — a = b, c distinct, alpha = beta = gamma = 90 deg
+    "tetragonal": dict(name="tetragonal", a=4.0, b=4.0, c=5.5, alpha=90, beta=90, gamma=90),
+    # orthorhombic — a, b, c distinct, alpha = beta = gamma = 90 deg
+    "orthorhombic": dict(name="orthorhombic", a=4.0, b=6.5, c=8.0, alpha=90, beta=90, gamma=90),
+    # hexagonal (sapphire setting) — a = b, gamma = 120 deg, alpha = beta = 90 deg
     "sapphire": dict(name="sapphire", a=4.758, c=12.991, gamma=120),
+    # trigonal (rhombohedral setting) — a = b = c, alpha = beta = gamma != 90 deg
+    "trigonal_rhombohedral": dict(
+        name="trigonal_rhombohedral",
+        a=7.0,
+        b=7.0,
+        c=7.0,
+        alpha=72,
+        beta=72,
+        gamma=72,
+    ),
+    # monoclinic — a, b, c distinct, alpha = gamma = 90 deg, beta != 90 deg
+    "monoclinic": dict(
+        name="monoclinic",
+        a=5.0,
+        b=7.0,
+        c=9.0,
+        alpha=90,
+        beta=110,
+        gamma=90,
+    ),
+    # triclinic — all parameters distinct, alpha != beta != gamma != 90 deg
     "triclinic": dict(
         name="triclinic",
         a=3.5,
@@ -386,7 +413,14 @@ GROUPS = {
 # hkl`` internally for these cases, so round-trip tests are not
 # xfailed.
 KNOWN_TTH_DISAGREEMENTS = {
-    # https://github.com/prjemian/hklpy2_solvers/issues/68
+    # https://github.com/prjemian/hklpy2_solvers/issues/68 - libhkl B-matrix
+    # bug for cells with direct alpha != 90 deg; ad_hoc + diffcalc-core
+    # agree exactly with each other and with the canonical BL1967 B,
+    # libhkl is the outlier.  Affects every cell whose direct alpha
+    # != 90 deg.  Currently the triclinic and trigonal-rhombohedral
+    # samples meet that criterion; cubic / tetragonal / orthorhombic /
+    # hexagonal-sapphire (gamma=120) / monoclinic (beta!=90, alpha=90)
+    # all have alpha = 90 deg and so escape the bug.
     ("euler_vertical", "fourcv", "triclinic", (0, 0, 6)): "issue #68",
     ("euler_vertical", "psic", "triclinic", (0, 0, 6)): "issue #68",
     ("euler_vertical", "fivec", "triclinic", (0, 0, 6)): "issue #68",
@@ -399,6 +433,18 @@ KNOWN_TTH_DISAGREEMENTS = {
     ("kappa_vertical", "kappa6c", "triclinic", (0, 0, 6)): "issue #68",
     ("kappa_horizontal", "kappa4ch", "triclinic", (0, 0, 6)): "issue #68",
     ("kappa_horizontal", "kappa6c", "triclinic", (0, 0, 6)): "issue #68",
+    ("euler_vertical", "fourcv", "trigonal_rhombohedral", (0, 0, 6)): "issue #68",
+    ("euler_vertical", "psic", "trigonal_rhombohedral", (0, 0, 6)): "issue #68",
+    ("euler_vertical", "fivec", "trigonal_rhombohedral", (0, 0, 6)): "issue #68",
+    ("euler_vertical", "sixc", "trigonal_rhombohedral", (0, 0, 6)): "issue #68",
+    ("euler_vertical", "diffcalc", "trigonal_rhombohedral", (0, 0, 6)): "issue #68",
+    ("euler_horizontal", "fourch", "trigonal_rhombohedral", (0, 0, 6)): "issue #68",
+    ("euler_horizontal", "psic", "trigonal_rhombohedral", (0, 0, 6)): "issue #68",
+    ("euler_horizontal", "diffcalc", "trigonal_rhombohedral", (0, 0, 6)): "issue #68",
+    ("kappa_vertical", "kappa4cv", "trigonal_rhombohedral", (0, 0, 6)): "issue #68",
+    ("kappa_vertical", "kappa6c", "trigonal_rhombohedral", (0, 0, 6)): "issue #68",
+    ("kappa_horizontal", "kappa4ch", "trigonal_rhombohedral", (0, 0, 6)): "issue #68",
+    ("kappa_horizontal", "kappa6c", "trigonal_rhombohedral", (0, 0, 6)): "issue #68",
 }
 
 # Known forward-solution gaps: parameter cases where ``forward()`` itself
@@ -426,6 +472,18 @@ KNOWN_FORWARD_GAPS = {
     # other reflection in the sapphire scan still solve.
     ("kappa_vertical", "kappa4cv", "sapphire", (0, 1, 2)): "issue #99",
     ("kappa_vertical", "kappa6c", "sapphire", (0, 1, 2)): "issue #99",
+    # https://github.com/prjemian/hklpy2_solvers/issues/69 and upstream
+    # https://github.com/BCDA-APS/ad_hoc_diffractometer/issues/285 -
+    # three ``ad_hoc`` horizontal-bisecting modes (``fourch bisecting``,
+    # ``psic bisecting_vertical``, ``kappa6c bisecting_horizontal``)
+    # decline the trigonal-rhombohedral reflection ``(1, 1, 0)`` on
+    # both ``ad_hoc_diffractometer 0.10.1`` and ``0.11.0``.  The
+    # ``hkl_soleil`` peers (``E4CH``, ``K6C``) solve the same
+    # reflection with ``|chi| ~ 51 deg`` / ``|kappa| ~ 97 deg``
+    # branches that the bisecting solvers do not enumerate.
+    ("euler_horizontal", "fourch", "trigonal_rhombohedral", (1, 1, 0)): "issue #69",
+    ("euler_horizontal", "psic", "trigonal_rhombohedral", (1, 1, 0)): "issue #69",
+    ("kappa_horizontal", "kappa6c", "trigonal_rhombohedral", (1, 1, 0)): "issue #69",
 }
 
 # CI-environment-dependent forward gaps: cases that pass locally on


### PR DESCRIPTION
- closes #69

## Summary

Expand ``SAMPLES`` in ``tests/test_cross_validation.py`` from 3 to 7
cells so the cross-validation suite exercises every crystal system.
Track the empirical findings discovered while landing the expansion.

## Cells added

| System | Lattice | Notes |
|---|---|---|
| tetragonal | ``a=4.0, b=4.0, c=5.5, α=β=γ=90`` | new |
| orthorhombic | ``a=4.0, b=6.5, c=8.0, α=β=γ=90`` | new |
| monoclinic | ``a=5.0, b=7.0, c=9.0, α=γ=90, β=110`` | new |
| trigonal-rhombohedral | ``a=b=c=7.0, α=β=γ=72`` | new (``a=7`` chosen so ``(0, 0, 6)`` lands at ``|2θ| ~ 91°``, comfortably away from the forward- and back-scatter limits the issue body"s original ``a=5`` puts it at) |
| cubic, sapphire, triclinic | unchanged | already present |

## Empirical findings

Probe phase (read-only): built 84 new simulators across 4 groups × variable entries × 4 new samples, then ran round-trip + cross-solver ``|2θ|`` checks bypassing xfail filtering.  Results:

* **121 clean passes.**
* **3 forward gaps**, all on ``ad_hoc`` horizontal-bisecting modes for trigonal-rhombohedral ``(1, 1, 0)``:
  * ``euler_horizontal / fourch / bisecting``
  * ``euler_horizontal / psic / bisecting_vertical``
  * ``kappa_horizontal / kappa6c / bisecting_horizontal``

  Verified same failures under ``ad_hoc_diffractometer 0.10.1`` — **pre-existing gap, not a v0.11.0 regression**.  Filed upstream as [BCDA-APS/ad_hoc_diffractometer#285](https://github.com/BCDA-APS/ad_hoc_diffractometer/issues/285) with reproducer and the libhkl reference angles showing the missed branch (``|χ| ~ 51°``, ``|κ| ~ 97°``).  Tracked in ``KNOWN_FORWARD_GAPS`` as ``issue #69``.

* **12 cross-solver ``|2θ|`` disagreements**, all on trigonal-rhombohedral ``(0, 0, 6)`` for every libhkl-backed peer.  Magnitude ``1.13°``, exactly the pattern predicted by the #68 root-cause analysis (libhkl B-matrix formula uses ``cos(α*)`` instead of ``cos(α)``; rhombohedral has ``α = 72° ≠ 90°``).  Tracked in ``KNOWN_TTH_DISAGREEMENTS`` as ``issue #68``.  This is **independent empirical confirmation** of the #68 hypothesis: the new ``α ≠ 90°`` cell type reproduces the exact same defect as the triclinic cell, while the three new ``α = 90°`` cells (tetragonal, orthorhombic, monoclinic) all agree to ``< 0.01°`` across every solver.

## Changes

* ``tests/test_cross_validation.py``
  * ``SAMPLES`` — extended from 3 → 7 cells, with one-line comments naming each crystal system"s constraint.
  * ``KNOWN_TTH_DISAGREEMENTS`` — +12 trigonal-rhombohedral ``(0, 0, 6)`` entries tagged ``issue #68``; comment block extended with the post-#68 rule (``α ≠ 90°``).
  * ``KNOWN_FORWARD_GAPS`` — +3 trigonal-rhombohedral ``(1, 1, 0)`` entries tagged ``issue #69`` and cross-linked to upstream #285.
* ``RELEASE_NOTES.rst`` — 1 ``New Features`` + 2 ``Fixes`` one-liners in the SEMVER block.

## QC

* ``pytest tests/`` — **878 passed (+284 from baseline), 34 xfailed, 6 xpassed, 0 failed**, runtime ~40 s.
* Coverage — **100.000%** line + branch (``fail_under = 100``).
* ``pre-commit run --all-files`` — all hooks pass.
* ``make -C docs html`` — clean rebuild, zero warnings, zero errors.

## Out of scope

* Did not add per-sample extra reflections beyond the default ``(0, 0, 6) / (1, 1, 0)`` pair — matches the cubic/triclinic precedent; new samples carry just the two bootstrap reflections.
* Did not touch ``BOOTSTRAP_BY_GROUP`` or any of the ``_rough_*_positions`` helpers — the existing bootstrap recipes + PR #94"s retry handled all 4 new cells without modification.
* Did not touch issue #83 or its ``CI_ENV_DEPENDENT_GAPS`` entries.

## Cross-links

* Upstream libhkl B-matrix bug report (no public tracker; staged locally for patch submission): ``/tmp/opencode/libhkl-bmatrix-triclinic.md`` — updated with the rhombohedral confirmation alongside this PR.
* Upstream ad_hoc gap: [BCDA-APS/ad_hoc_diffractometer#285](https://github.com/BCDA-APS/ad_hoc_diffractometer/issues/285).

Agent: OpenCode (argo/claudeopus47)