### PR TITLE
feat: surface ad_hoc_diffractometer.reference helpers on AdHocSolver

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -39,6 +39,7 @@ describe future plans.
     * Add vertical four-circle cross-validation suite against ``hkl_soleil``.  :issue:`50`
     * Add vertical kappa four-circle cross-validation group against ``hkl_soleil``.  :issue:`66`
     * Expand cross-validation sample set to all seven crystal systems.  :issue:`69`
+    * Surface ``ad_hoc_diffractometer.reference`` helpers on ``AdHocSolver``.  :issue:`101`
 
     Enhancements
     ~~~~~~~~~~~~
@@ -46,6 +47,7 @@ describe future plans.
     * Add guide-regression smoke test to catch API drift in how-to guides.  :issue:`88`
     * Add regression test documenting ``ad_hoc/kappa6c bisecting_horizontal`` reflection-pattern gap.  :issue:`77`
     * Add regression test documenting ``ad_hoc/psic bisecting_horizontal`` asymmetric-reflection gap.  :issue:`71`
+    * Document derived-quantity access (ψ, α_i, β_out, n_az, OMEGA) for ``AdHocSolver``.  :issue:`63`
     * Expand sapphire cross-validation matrix with ``(1, 1, 3)`` and ``(1, 1, 6)``.  :issue:`77`
 
     Fixes

--- a/docs/source/guide_ad_hoc.rst
+++ b/docs/source/guide_ad_hoc.rst
@@ -143,6 +143,71 @@ motor positions.  ``fourc.real_position`` is the current readout of
 all real axes; pass a different set of values to compute ``(h, k, l)``
 at a hypothetical position instead.
 
+Derived quantities (ψ, α_i, β_out, n_az, OMEGA)
+------------------------------------------------
+
+``AdHocSolver`` exposes the six derived-quantity helpers from
+``ad_hoc_diffractometer.reference`` as methods, so users do not need
+to reach into ``solver._geom``:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 40 40
+
+   * - Method
+     - Returns
+     - Geometry prerequisite
+   * - ``psi_angle(angles=None)``
+     - Azimuthal angle ψ (deg) from motors
+     - ``azimuthal_reference`` set
+   * - ``incidence_angle(angles=None)``
+     - Incidence angle α_i (deg)
+     - ``surface_normal`` set
+   * - ``exit_angle(angles=None)``
+     - Exit angle β_out (deg)
+     - ``surface_normal`` set
+   * - ``naz_angle(angles=None)``
+     - Lab-frame azimuthal angle of n̂ (deg)
+     - ``surface_normal`` set
+   * - ``omega_pseudo(angles=None)``
+     - SPEC ``OMEGA`` pseudo-angle (deg)
+     - none
+   * - ``natural_psi(h, k, l)``
+     - Natural ψ (deg) from UB; ``None`` if undefined
+     - ``azimuthal_reference`` set
+
+``angles`` may be a dict keyed by real-axis name (any subset); ``None``
+(default) uses the geometry's current angles.  Unknown axis names raise
+:class:`~hklpy2.exceptions.SolverError`; a non-dict input raises
+``TypeError``.
+
+The reference vectors ``azimuthal_reference`` and ``surface_normal``
+are still configured on the underlying geometry object:
+
+.. code-block:: python
+
+   import hklpy2
+
+   psic2 = hklpy2.creator(name="psic2", geometry="psic", solver="ad_hoc")
+   solver = psic2.core.solver
+   solver._geom.azimuthal_reference = (0, 0, 1)
+   solver._geom.surface_normal = (1, 1, 6)
+   solver._geom.wavelength = 1.0
+
+   angles = dict(mu=0, eta=20, chi=30, phi=15, nu=0, delta=40)
+   solver.set_reals(angles)
+
+   psi = solver.psi_angle(angles)
+   alpha_i = solver.incidence_angle(angles)
+   beta_out = solver.exit_angle(angles)
+   naz = solver.naz_angle(angles)
+   omega = solver.omega_pseudo(angles)
+   natural = solver.natural_psi(1, 1, 1)
+
+See the upstream
+`ad_hoc_diffractometer.reference <https://bcda-aps.github.io/ad_hoc_diffractometer/latest/api/reference.html>`_
+module for the mathematical definitions.
+
 Available geometries at a glance
 ---------------------------------
 

--- a/src/hklpy2_solvers/ad_hoc_solver.py
+++ b/src/hklpy2_solvers/ad_hoc_solver.py
@@ -27,6 +27,12 @@ from ad_hoc_diffractometer.mode import (
     ConstraintViolation,
     EwaldSphereViolation,
 )
+from ad_hoc_diffractometer.reference import exit_angle as _ref_exit_angle
+from ad_hoc_diffractometer.reference import incidence_angle as _ref_incidence_angle
+from ad_hoc_diffractometer.reference import natural_psi as _ref_natural_psi
+from ad_hoc_diffractometer.reference import naz_angle as _ref_naz_angle
+from ad_hoc_diffractometer.reference import omega_pseudo as _ref_omega_pseudo
+from ad_hoc_diffractometer.reference import psi_angle as _ref_psi_angle
 from ad_hoc_diffractometer.refinement import refine_lattice_bl1967
 from hklpy2.backends.base import SolverBase
 from hklpy2.backends.typing import ReflectionDict
@@ -148,6 +154,23 @@ class AdHocSolver(SolverBase):
         if self._geom.wavelength is None:
             self._geom.wavelength = 1.0
         ahd.ub_identity(self._geom.sample)
+
+    def _normalize_angles(self, angles: dict[str, float] | None) -> dict[str, float] | None:
+        """Validate the optional motor-angles dict used by reference helpers.
+
+        Returns ``None`` unchanged (upstream interprets this as
+        "use the geometry's current angles").  A dict is shallow-copied
+        with values coerced to ``float``.  Unknown axis names raise
+        :class:`SolverError`; a non-dict input raises ``TypeError``.
+        """
+        if angles is None:
+            return None
+        if not isinstance(angles, dict):
+            raise TypeError(f"angles must be a dict[str, float] or None, received {angles!r}")
+        unknown = set(angles) - set(self._real_axes)
+        if unknown:
+            raise SolverError(f"Unknown axis name(s) {sorted(unknown)}; expected subset of {self._real_axes}")
+        return {k: float(v) for k, v in angles.items()}
 
     # ------------------------------------------------------------------
     # SolverBase abstract methods
@@ -540,6 +563,94 @@ class AdHocSolver(SolverBase):
         # Re-apply lattice if we had one.
         if self._lattice:
             self.lattice = self._lattice
+
+    # ------------------------------------------------------------------
+    # Reference helpers (backend-specific derived quantities).
+    #
+    # Thin wrappers around ``ad_hoc_diffractometer.reference`` so users
+    # do not need to reach into ``solver._geom``.  See the
+    # "Derived quantities" section of the AdHoc user guide.
+    # ------------------------------------------------------------------
+
+    def exit_angle(self, angles: dict[str, float] | None = None) -> float:
+        """Exit angle β_out (deg).
+
+        Requires :attr:`~ad_hoc_diffractometer.diffractometer.AdHocDiffractometer.surface_normal`
+        to be set on the underlying geometry.
+
+        PARAMETERS
+
+        angles : dict[str, float] or None
+            Motor angles in degrees keyed by real-axis name.  ``None``
+            (default) means use the geometry's current angles.
+        """
+        return float(_ref_exit_angle(self._geom, angles=self._normalize_angles(angles)))
+
+    def incidence_angle(self, angles: dict[str, float] | None = None) -> float:
+        """Incidence angle α_i (deg).
+
+        Requires :attr:`~ad_hoc_diffractometer.diffractometer.AdHocDiffractometer.surface_normal`
+        to be set on the underlying geometry.
+
+        PARAMETERS
+
+        angles : dict[str, float] or None
+            Motor angles in degrees keyed by real-axis name.  ``None``
+            (default) means use the geometry's current angles.
+        """
+        return float(_ref_incidence_angle(self._geom, angles=self._normalize_angles(angles)))
+
+    def natural_psi(self, h: float, k: float, l: float) -> float | None:  # noqa: E741
+        """Natural azimuthal angle ψ (deg) for reflection ``(h, k, l)`` from UB.
+
+        Uses ``UB @ (h, k, l)`` and ``UB @ azimuthal_reference``; **no
+        motor angles enter the calculation**.  Returns ``None`` when the
+        reflection is parallel to the azimuthal reference (ψ undefined).
+
+        Requires :attr:`~ad_hoc_diffractometer.diffractometer.AdHocDiffractometer.azimuthal_reference`
+        to be set on the underlying geometry.
+        """
+        result = _ref_natural_psi(self._geom, float(h), float(k), float(l))
+        return None if result is None else float(result)
+
+    def naz_angle(self, angles: dict[str, float] | None = None) -> float:
+        """Lab-frame azimuthal angle of n̂, ``naz`` (deg).
+
+        Requires :attr:`~ad_hoc_diffractometer.diffractometer.AdHocDiffractometer.surface_normal`
+        to be set on the underlying geometry.
+
+        PARAMETERS
+
+        angles : dict[str, float] or None
+            Motor angles in degrees keyed by real-axis name.  ``None``
+            (default) means use the geometry's current angles.
+        """
+        return float(_ref_naz_angle(self._geom, angles=self._normalize_angles(angles)))
+
+    def omega_pseudo(self, angles: dict[str, float] | None = None) -> float:
+        """SPEC ``OMEGA`` pseudo-angle (deg), in ``[-90°, +90°]``.
+
+        PARAMETERS
+
+        angles : dict[str, float] or None
+            Motor angles in degrees keyed by real-axis name.  ``None``
+            (default) means use the geometry's current angles.
+        """
+        return float(_ref_omega_pseudo(self._geom, angles=self._normalize_angles(angles)))
+
+    def psi_angle(self, angles: dict[str, float] | None = None) -> float:
+        """Azimuthal angle ψ (deg) from motor positions.
+
+        Requires :attr:`~ad_hoc_diffractometer.diffractometer.AdHocDiffractometer.azimuthal_reference`
+        to be set on the underlying geometry.
+
+        PARAMETERS
+
+        angles : dict[str, float] or None
+            Motor angles in degrees keyed by real-axis name.  ``None``
+            (default) means use the geometry's current angles.
+        """
+        return float(_ref_psi_angle(self._geom, angles=self._normalize_angles(angles)))
 
     @property
     def UB(self) -> Matrix3x3:

--- a/tests/test_ad_hoc_solver.py
+++ b/tests/test_ad_hoc_solver.py
@@ -1869,3 +1869,188 @@ def test_creator_end_to_end(parms, context):
         sim = hklpy2.creator(solver="ad_hoc", geometry=parms["geometry"])
         assert sim.core.solver.name == "ad_hoc"
         assert sim.core.solver.geometry == parms["geometry"]
+
+
+# ---------------------------------------------------------------------------
+# Reference helpers (issues #63, #101, #103): six thin wrappers around
+# ``ad_hoc_diffractometer.reference`` exposed as methods on ``AdHocSolver``.
+# ---------------------------------------------------------------------------
+
+
+REF_HELPER_ANGLES = dict(mu=0.0, eta=20.0, chi=30.0, phi=15.0, nu=0.0, delta=40.0)
+"""Non-degenerate motor positions for the reference-helper tests."""
+
+
+def _ref_helper_solver(*, configure: bool = True) -> AdHocSolver:
+    """Build a psic AdHocSolver wired for reference-helper tests.
+
+    When ``configure`` is False the geometry is left without
+    ``azimuthal_reference`` / ``surface_normal`` so that failure
+    paths in the upstream helpers can be exercised.
+    """
+    import ad_hoc_diffractometer as ahd
+
+    solver = AdHocSolver(geometry="psic")
+    solver._geom.wavelength = WAVELENGTH
+    ahd.ub_identity(solver._geom.sample)
+    solver.set_reals(REF_HELPER_ANGLES)
+    if configure:
+        solver._geom.azimuthal_reference = (0, 0, 1)
+        solver._geom.surface_normal = (1, 1, 6)
+    return solver
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(
+                method="psi_angle",
+                args=(REF_HELPER_ANGLES,),
+                expected=pytest.approx(97.63074021243006, abs=1e-9),
+            ),
+            does_not_raise(),
+            id="psi_angle with explicit angles dict",
+        ),
+        pytest.param(
+            dict(
+                method="psi_angle",
+                args=(),
+                expected=pytest.approx(97.63074021243006, abs=1e-9),
+            ),
+            does_not_raise(),
+            id="psi_angle with default None angles uses current geometry",
+        ),
+        pytest.param(
+            dict(
+                method="incidence_angle",
+                args=(REF_HELPER_ANGLES,),
+                expected=pytest.approx(6.748271970061214, abs=1e-9),
+            ),
+            does_not_raise(),
+            id="incidence_angle with explicit angles dict",
+        ),
+        pytest.param(
+            dict(
+                method="exit_angle",
+                args=(REF_HELPER_ANGLES,),
+                expected=pytest.approx(19.456294998006513, abs=1e-9),
+            ),
+            does_not_raise(),
+            id="exit_angle with explicit angles dict",
+        ),
+        pytest.param(
+            dict(
+                method="naz_angle",
+                args=(REF_HELPER_ANGLES,),
+                expected=pytest.approx(80.53767779197439, abs=1e-9),
+            ),
+            does_not_raise(),
+            id="naz_angle with explicit angles dict",
+        ),
+        pytest.param(
+            dict(
+                method="omega_pseudo",
+                args=(REF_HELPER_ANGLES,),
+                expected=pytest.approx(0.0, abs=1e-9),
+            ),
+            does_not_raise(),
+            id="omega_pseudo with explicit angles dict",
+        ),
+        pytest.param(
+            dict(
+                method="natural_psi",
+                args=(1, 1, 1),
+                expected=pytest.approx(120.0, abs=1e-9),
+            ),
+            does_not_raise(),
+            id="natural_psi returns float for (1, 1, 1)",
+        ),
+        pytest.param(
+            dict(
+                method="natural_psi",
+                args=(0, 0, 1),
+                expected=None,
+            ),
+            does_not_raise(),
+            id="natural_psi returns None when reflection parallel to azimuthal reference",
+        ),
+        pytest.param(
+            dict(
+                method="psi_angle",
+                args=({"bogus": 0.0},),
+                expected=None,
+            ),
+            pytest.raises(SolverError, match=re.escape("Unknown axis name(s) ['bogus']")),
+            id="psi_angle with unknown axis name raises SolverError",
+        ),
+        pytest.param(
+            dict(
+                method="incidence_angle",
+                args=([0.0, 0.0, 0.0],),
+                expected=None,
+            ),
+            pytest.raises(TypeError, match=re.escape("angles must be a dict[str, float] or None")),
+            id="incidence_angle with non-dict angles raises TypeError",
+        ),
+    ],
+)
+def test_reference_helpers(parms, context):
+    """Cover all six reference-helper methods plus their failure paths.
+
+    Verifies that ``AdHocSolver.{psi,incidence,exit,naz}_angle``,
+    ``omega_pseudo`` and ``natural_psi`` forward to
+    :mod:`ad_hoc_diffractometer.reference`, accept the documented
+    inputs (dict-of-angles, default ``None``, or ``h, k, l``), and that
+    the wrapper's own validation surfaces ``SolverError`` / ``TypeError``
+    for malformed inputs.  Closes :issue:`63`, :issue:`101`,
+    :issue:`103`.
+    """
+    with context:
+        solver = _ref_helper_solver()
+        method = getattr(solver, parms["method"])
+        result = method(*parms["args"])
+        if parms["expected"] is None:
+            assert result is None
+        else:
+            assert result == parms["expected"]
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(method="psi_angle"),
+            pytest.raises(ValueError, match=re.escape("azimuthal_reference")),
+            id="psi_angle without azimuthal_reference raises upstream ValueError",
+        ),
+        pytest.param(
+            dict(method="incidence_angle"),
+            pytest.raises(ValueError, match=re.escape("surface_normal")),
+            id="incidence_angle without surface_normal raises upstream ValueError",
+        ),
+        pytest.param(
+            dict(method="exit_angle"),
+            pytest.raises(ValueError, match=re.escape("surface_normal")),
+            id="exit_angle without surface_normal raises upstream ValueError",
+        ),
+        pytest.param(
+            dict(method="naz_angle"),
+            pytest.raises(ValueError, match=re.escape("surface_normal")),
+            id="naz_angle without surface_normal raises upstream ValueError",
+        ),
+    ],
+)
+def test_reference_helpers_missing_geometry_config(parms, context):
+    """Preconditions documented on each wrapper are enforced by upstream.
+
+    Wrappers do **not** silently default ``azimuthal_reference`` or
+    ``surface_normal``; with neither set, the upstream call raises a
+    ``ValueError`` mentioning the missing attribute.  This test pins
+    that behaviour so users get a useful diagnostic rather than a
+    silent garbage answer.
+    """
+    with context:
+        solver = _ref_helper_solver(configure=False)
+        method = getattr(solver, parms["method"])
+        method(REF_HELPER_ANGLES)


### PR DESCRIPTION
- closes #63
- closes #101
- closes #103

Implements **Option C** from #101: six thin public method wrappers
on `AdHocSolver` forwarding to `ad_hoc_diffractometer.reference`
(`incidence_angle`, `exit_angle`, `psi_angle`, `naz_angle`,
`omega_pseudo`, `natural_psi`).  Users no longer need to reach
into `solver._geom` to compute these derived quantities.

Highlights
----------

* Validation lives in a single private `_normalize_angles` helper:
  unknown axis names raise `SolverError`; non-dict input raises
  `TypeError`; `None` is forwarded to upstream and means
  "use current geometry angles".
* `natural_psi` preserves upstream `None` sentinel for reflections
  parallel to `azimuthal_reference`.
* Wrappers do **not** silently default `azimuthal_reference` or
  `surface_normal`; users still configure those on the underlying
  geometry.  Tests pin the upstream `ValueError` diagnostics so
  users get a useful message.
* New "Derived quantities (psi, alpha_i, beta_out, n_az, OMEGA)"
  section in `docs/source/guide_ad_hoc.rst` with a worked psic
  example.  The guide-regression smoke test exercises the example.
* 14 new parametrized tests cover all six methods, the
  `None`-default path, the `None`-return path, and all
  validation/error paths.  Project coverage remains at 100%
  (line + branch).

Out of scope
------------

* Wrapping `azimuthal_reference` / `surface_normal` as solver
  properties — those are geometry configuration, separate concern.
* `DiffcalcSolver` — has its own diagnostics surface, separate
  review (noted in #101).

Agent: OpenCode (argo/claudeopus47)