### PR TITLE
refactor: rename DiffcalcSolver modes and realign canonical bisecting pairings

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -40,6 +40,7 @@ describe future plans.
     ~~~~~~~~~~~~
 
     * Add ``cross-validation.yml`` workflow running libhkl-backed tests via conda-forge.  :issue:`65`
+    * Add ``DiffcalcSolver.register_mode`` / ``unregister_mode`` for runtime constraint sets.  :issue:`106`
     * Add horizontal four-circle cross-validation group against ``hkl_soleil``.  :issue:`67`
     * Add horizontal kappa cross-validation group against ``hkl_soleil``.  :issue:`75`
     * Add six-circle bisecting peers to cross-validation groups.  :issue:`64`

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -29,6 +29,13 @@ describe future plans.
 
     Expected release: tba
 
+    Breaking Changes
+    ~~~~~~~~~~~~~~~~
+
+    * Realign ``DiffcalcSolver`` bisect modes to canonical vertical/horizontal pairings.  :issue:`97`
+    * Rename all ``DiffcalcSolver`` modes; drop ``4S+2D`` prefix and use ``fixed_<axis>`` form.  :issue:`97`
+    * Set ``DiffcalcSolver`` default mode to ``bisect fixed_mu fixed_nu`` (canonical vertical bisector).  :issue:`97`
+
     New Features
     ~~~~~~~~~~~~
 
@@ -44,6 +51,7 @@ describe future plans.
     Enhancements
     ~~~~~~~~~~~~
 
+    * Add cross-reference table mapping common-convention names to diffcalc modes.  :issue:`97`
     * Add guide-regression smoke test to catch API drift in how-to guides.  :issue:`88`
     * Add regression test documenting ``ad_hoc/kappa6c bisecting_horizontal`` reflection-pattern gap.  :issue:`77`
     * Add regression test documenting ``ad_hoc/psic bisecting_horizontal`` asymmetric-reflection gap.  :issue:`71`
@@ -203,7 +211,7 @@ Fixes
 ~~~~~
 
 * Fix ``ModuleNotFoundError: No module named 'hklpy2.misc'``; update imports to ``hklpy2.exceptions`` and ``hklpy2.utils`` for compatibility with hklpy2 ≥ 0.6.0.  :issue:`31`
-* Fix ``forward()`` raising ``AttributeError: no attribute 'set_reals'``; add ``set_reals()`` and ``UB`` setter, change default mode to ``4S+2D mu_chi_phi_fixed``.  :issue:`29`
+* Fix ``forward()`` raising ``AttributeError: no attribute 'set_reals'``; add ``set_reals()`` and ``UB`` setter, change default mode to ``fixed_mu fixed_chi fixed_phi``.  :issue:`29`
 * Fix ``calc_UB()`` raising ``SolverError: Lattice must be set``; override ``sample`` setter to push lattice into diffcalc.  :issue:`25`
 * Fix ``wh()`` raising ``SolverError: UB matrix has not been set`` before reflections are added.  :issue:`24`
 

--- a/docs/source/_static/diffcalc_4s_2d.yml
+++ b/docs/source/_static/diffcalc_4s_2d.yml
@@ -190,4 +190,4 @@ beam:
   energy_units: keV
   wavelength_units: angstrom
 presets:
-  4S+2D mu_chi_phi_fixed: {}
+  fixed_mu fixed_chi fixed_phi: {}

--- a/docs/source/geometries.rst
+++ b/docs/source/geometries.rst
@@ -741,7 +741,7 @@ H. You, *J. Appl. Cryst.* **32**, 614 (1999) six-circle geometry.
    * - Pseudo axes
      - ``h``, ``k``, ``l``
    * - Default mode
-     - ``4S+2D bisect_eta_fixed nu_fixed``
+     - ``bisect fixed_mu fixed_nu``
 
 Operating modes
 ^^^^^^^^^^^^^^^
@@ -760,95 +760,95 @@ remaining axes are held constant (``axes_c``, derived by hklpy2).
      - Fixed constraints
      - writable(s)
      - extra(s)
-   * - ``4S+2D mu_fixed a_eq_b delta_fixed``
+   * - ``a_eq_b fixed_delta fixed_mu``
      - delta=0, a_eq_b, mu=0
      - nu, eta, chi, phi
      -
-   * - ``4S+2D mu_fixed a_eq_b nu_fixed``
+   * - ``a_eq_b fixed_nu fixed_mu``
      - nu=0, a_eq_b, mu=0
      - delta, eta, chi, phi
      -
-   * - ``4S+2D eta_fixed a_eq_b delta_fixed``
+   * - ``a_eq_b fixed_delta fixed_eta``
      - delta=0, a_eq_b, eta=0
      - mu, nu, chi, phi
      -
-   * - ``4S+2D phi_fixed psi_fixed nu_fixed``
+   * - ``fixed_nu fixed_psi fixed_phi``
      - nu=0, psi=0, phi=0
      - mu, delta, eta, chi
      -
-   * - ``4S+2D chi_phi_fixed delta_fixed``
+   * - ``fixed_delta fixed_chi fixed_phi``
      - delta=0, chi=0, phi=0
      - mu, nu, eta
      -
-   * - ``4S+2D mu_eta_fixed delta_fixed``
+   * - ``fixed_delta fixed_mu fixed_eta``
      - delta=0, mu=0, eta=0
      - nu, chi, phi
      -
-   * - ``4S+2D mu_phi_fixed delta_fixed``
+   * - ``fixed_delta fixed_mu fixed_phi``
      - delta=0, mu=0, phi=0
      - nu, eta, chi
      -
-   * - ``4S+2D mu_chi_fixed nu_fixed``
+   * - ``fixed_nu fixed_mu fixed_chi``
      - nu=0, mu=0, chi=0
      - delta, eta, phi
      -
-   * - ``4S+2D eta_phi_fixed nu_fixed``
+   * - ``fixed_nu fixed_eta fixed_phi``
      - nu=0, eta=0, phi=0
      - mu, delta, chi
      -
-   * - ``4S+2D eta_chi_fixed nu_fixed``
+   * - ``fixed_nu fixed_eta fixed_chi``
      - nu=0, eta=0, chi=0
      - mu, delta, phi
      -
-   * - ``4S+2D bisect_mu_fixed delta_fixed``
-     - delta=0, bisect, mu=0
-     - nu, eta, chi, phi
+   * - ``bisect fixed_mu fixed_nu``
+     - bisect, mu=0, nu=0
+     - delta, eta, chi, phi
      -
-   * - ``4S+2D bisect_eta_fixed nu_fixed``
-     - nu=0, bisect, eta=0
-     - mu, delta, chi, phi
+   * - ``bisect fixed_eta fixed_delta``
+     - bisect, eta=0, delta=0
+     - mu, nu, chi, phi
      -
-   * - ``4S+2D bisect_omega_fixed nu_fixed``
-     - nu=0, bisect, omega=0
+   * - ``bisect fixed_omega fixed_nu``
+     - bisect, omega=0, nu=0
      - mu, delta, eta, chi, phi
      -
-   * - ``4S+2D chi_phi_fixed a_eq_b``
+   * - ``a_eq_b fixed_chi fixed_phi``
      - a_eq_b, chi=0, phi=0
      - mu, delta, nu, eta
      -
-   * - ``4S+2D chi_eta_fixed a_eq_b``
+   * - ``a_eq_b fixed_chi fixed_eta``
      - a_eq_b, chi=0, eta=0
      - mu, delta, nu, phi
      -
-   * - ``4S+2D chi_mu_fixed a_eq_b``
+   * - ``a_eq_b fixed_chi fixed_mu``
      - a_eq_b, chi=0, mu=0
      - delta, nu, eta, phi
      -
-   * - ``4S+2D mu_eta_fixed a_eq_b``
+   * - ``a_eq_b fixed_mu fixed_eta``
      - a_eq_b, mu=0, eta=0
      - delta, nu, chi, phi
      -
-   * - ``4S+2D mu_phi_fixed a_eq_b``
+   * - ``a_eq_b fixed_mu fixed_phi``
      - a_eq_b, mu=0, phi=0
      - delta, nu, eta, chi
      -
-   * - ``4S+2D eta_phi_fixed a_eq_b``
+   * - ``a_eq_b fixed_eta fixed_phi``
      - a_eq_b, eta=0, phi=0
      - mu, delta, nu, chi
      -
-   * - ``4S+2D eta_chi_phi_fixed``
+   * - ``fixed_eta fixed_chi fixed_phi``
      - eta=0, chi=0, phi=0
      - mu, delta, nu
      -
-   * - ``4S+2D mu_chi_phi_fixed``
+   * - ``fixed_mu fixed_chi fixed_phi``
      - mu=0, chi=0, phi=0
      - delta, nu, eta
      -
-   * - ``4S+2D mu_eta_phi_fixed``
+   * - ``fixed_mu fixed_eta fixed_phi``
      - mu=0, eta=0, phi=0
      - delta, nu, chi
      -
-   * - ``4S+2D mu_eta_chi_fixed``
+   * - ``fixed_mu fixed_eta fixed_chi``
      - mu=0, eta=0, chi=0
      - delta, nu, phi
      -
@@ -856,45 +856,77 @@ remaining axes are held constant (``axes_c``, derived by hklpy2).
 Default mode
 ^^^^^^^^^^^^
 
-The default mode is ``4S+2D bisect_eta_fixed nu_fixed`` (bisect,
-eta=0, nu=0).  This is equivalent to ``bisecting_vertical`` in E6C
-terminology: scattering stays in the vertical plane with the sample
-angle bisecting the detector angle (``eta = delta/2``).
+The default mode is ``bisect fixed_mu fixed_nu`` (canonical
+``bisecting_vertical``: ``bisect``, ``mu=0``, ``nu=0``).
+Equivalent to ``bisecting_vertical`` in E6C terminology: scattering
+stays in the vertical plane on the ``delta`` axis with the sample
+bisecting the scattering angle.
 
-.. note:: **Bisector modes**
+.. note:: **Bisecting modes**
 
    Following You (1999) Figure 1 (see also
    `diffcalc-core docs <https://diffcalc-core.readthedocs.io>`_),
-   ``nu`` rotates about the vertical axis and swings the detector
-   **horizontally**; ``delta`` rotates about the horizontal axis and swings
-   the detector **vertically**.
+   ``delta`` rotates about a horizontal axis and swings the detector
+   **vertically**; ``nu`` rotates about a vertical axis and swings the
+   detector **horizontally**.  ``mu`` is the horizontal-arm sample
+   axis (rotates about the vertical lab axis); ``eta`` rotates about a
+   horizontal axis.
 
-   The ``bisect`` constraint implements ``eta = delta/2`` (vertical
-   bisector).  ``4S+2D bisect_eta_fixed nu_fixed`` (bisect + eta=0 +
-   nu=0) is equivalent to a ``bisecting_vertical`` mode: scattering
-   stays in the vertical plane with the sample bisecting the detector
-   angle.  ``4S+2D bisect_mu_fixed delta_fixed`` (bisect + mu=0 +
-   delta=0) is the horizontal counterpart.
+   diffcalc's ``bisect`` constraint pairs with one sample axis at a
+   time (``mu``, ``eta``, or ``omega``) and pins the *other*
+   in-plane axes so that the active detector axis bisects with that
+   sample axis:
 
-   In the mode name the *bisected sample axis* is stated; the
-   corresponding *detector axis* is implied by the bisect constraint
-   (``delta``).
+   .. list-table::
+      :header-rows: 1
+      :widths: 30 20 25 25
+
+      * - Mode
+        - Family
+        - Pinned axes
+        - Active axes
+      * - ``bisect fixed_mu fixed_nu``
+        - bisecting vertical (≡ E6C ``bisecting_vertical``)
+        - ``mu=0``, ``nu=0``
+        - ``delta`` and ``eta`` acting as ttheta and ttheta/2,
+          respectively
+      * - ``bisect fixed_eta fixed_delta``
+        - bisecting horizontal (≡ E6C ``bisecting_horizontal``)
+        - ``eta=0``, ``delta=0``
+        - ``nu`` and ``mu`` acting as ttheta and ttheta/2,
+          respectively
+      * - ``bisect fixed_omega fixed_nu``
+        - bisecting vertical with ``omega``-tilt (general You case)
+        - ``omega=0``, ``nu=0``
+        - ``mu``, ``eta``, ``delta``
 
 Mode naming convention
 ^^^^^^^^^^^^^^^^^^^^^^
 
-All mode names follow the pattern ``4S+2D <constraints>``, where ``4S+2D``
-identifies the You (1999) geometry and the suffix encodes the three fixed
-constraints:
+Each mode name lists the three diffcalc constraints separated by
+spaces.  Token order is **keyword constraints first**
+(``a_eq_b``, ``bisect``, ``bin_eq_bout``), then ``fixed_<axis>``
+tokens.  For all-``fixed_*`` modes the conventional order is
+**detector → sample(s)**.
 
-- ``<axis>_fixed`` or ``<ax1>_<ax2>_fixed`` — motor axis (or axes) fixed at
-  zero.
+- ``fixed_<axis>`` — that axis or pseudo-angle is pinned at ``0``.
+  Applies to detector axes (``delta``, ``nu``), reference angles
+  (``psi``), and sample axes (``mu``, ``eta``, ``chi``, ``phi``,
+  ``omega``).
 - ``a_eq_b`` — reference-vector constraint: azimuthal reference equals
   scattering vector direction.  **Caution:** singular when the scattering
   vector is parallel to the reference vector; avoid as a default.
-- ``bisect`` — bisector condition: ``eta = delta/2``.  The bisected sample
-  axis (e.g. ``eta``) is named; the detector axis (``delta``) is implied.
-- ``psi_fixed``, ``omega_fixed`` — azimuthal or omega angle fixed at zero.
+- ``bin_eq_bout`` — reference constraint: incidence equals exit angle.
+- ``bisect`` — sample bisector condition (one of three diffcalc
+  variants, see "Bisector modes" above).
+
+For example, ``bisect fixed_mu fixed_nu`` encodes
+``{bisect: True, mu: 0, nu: 0}`` and ``a_eq_b fixed_delta fixed_mu``
+encodes ``{a_eq_b: True, delta: 0, mu: 0}``.  See the
+:ref:`guide_diffcalc` "Cross-reference to common conventions" section
+for a mapping between these names and the
+``bisecting_vertical`` / ``lifting_detector_<axis>`` / ``double_diffraction``
+vocabulary used by other solvers.
 
 Extensibility
 ^^^^^^^^^^^^^

--- a/docs/source/guide_diffcalc.rst
+++ b/docs/source/guide_diffcalc.rst
@@ -137,6 +137,52 @@ A valid combination is **at most one** detector constraint, **at
 most one** reference constraint, and **one to three** sample
 constraints, totalling three constraints overall.
 
+Register a runtime mode
+-----------------------
+
+The 23 built-in modes do not exhaust the constraint combinations
+that diffcalc-core implements.  Use
+:meth:`~hklpy2_solvers.diffcalc_solver.DiffcalcSolver.register_mode`
+to add a new mode at runtime without forking the package:
+
+.. code-block:: python
+
+   solver = psic.core.solver
+   solver.register_mode(
+       "fixed_delta fixed_eta fixed_chi",
+       {"delta": 0.0, "eta": 0.0, "chi": 0.0},
+   )
+   psic.core.mode = "fixed_delta fixed_eta fixed_chi"
+
+The mode is validated against
+:class:`diffcalc.hkl.constraints.Constraints` before acceptance:
+the name cannot clash with a built-in, the dict must have exactly
+three diffcalc-recognised constraints with no same-category
+conflicts, and the combination must satisfy
+``is_current_mode_implemented()``.  Otherwise
+:class:`~hklpy2.exceptions.SolverError` is raised with a message
+naming the offending input.
+
+Remove a user mode with
+:meth:`~hklpy2_solvers.diffcalc_solver.DiffcalcSolver.unregister_mode`.
+Switch away first if the mode is currently active, so the
+diffractometer's cached mode stays consistent with the solver:
+
+.. code-block:: python
+
+   psic.core.mode = "bisect fixed_mu fixed_nu"
+   solver.unregister_mode("fixed_delta fixed_eta fixed_chi")
+
+.. warning::
+
+   User-registered modes live only for the lifetime of the solver
+   instance.  ``Diffractometer.export()`` /
+   ``Diffractometer.restore()`` / ``simulator_from_config()`` do
+   not round-trip them through the YAML configuration, because
+   hklpy2's configuration schema has no solver-defined state slot
+   today.  Re-register your modes in any process that loads a
+   saved configuration.  Tracked in :issue:`108`.
+
 Compute motor positions (forward)
 ---------------------------------
 

--- a/docs/source/guide_diffcalc.rst
+++ b/docs/source/guide_diffcalc.rst
@@ -69,14 +69,73 @@ Calculate the UB matrix
 Choose an operating mode
 ------------------------
 
-The default mode is ``4S+2D bisect_eta_fixed nu_fixed`` (vertical
-bisector: ``eta = delta/2``, eta=0, nu=0).  To change it:
+The default mode is ``bisect fixed_mu fixed_nu`` (canonical
+``bisecting_vertical``: ``mu=0``, ``nu=0``; ``delta`` and ``eta`` acting as
+ttheta and ttheta/2, respectively).  To choose a different mode:
 
 .. code-block:: python
 
-   psic.core.mode = "4S+2D mu_chi_phi_fixed"
+   psic.core.mode = "fixed_mu fixed_chi fixed_phi"
 
 See :ref:`geometry.diffcalc_4S_2D` for the full list of 23 modes.
+
+Cross-reference to common conventions
+-------------------------------------
+
+Mode names use diffcalc's constraint vocabulary directly
+(``fixed_<axis>``, ``bisect``, ``a_eq_b``, …) rather than the
+``bisecting_vertical`` / ``lifting_detector_<axis>`` /
+``double_diffraction`` vocabulary used by ``hkl_soleil`` and
+``ad_hoc`` solvers.  The table below maps the most common
+conventions onto the equivalent diffcalc mode:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 35 30
+
+   * - Common-convention name
+     - Equivalent diffcalc mode
+     - Notes
+   * - ``bisecting_vertical``
+     - ``bisect fixed_mu fixed_nu``
+     - Vertical bisector: ``mu=0``, ``nu=0``.  ``delta`` swings the
+       detector vertically; ``eta`` is the bisecting sample axis.
+       Default.
+   * - ``bisecting_horizontal``
+     - ``bisect fixed_eta fixed_delta``
+     - Horizontal bisector: ``eta=0``, ``delta=0``.  ``nu`` swings
+       the detector horizontally; ``mu`` is the bisecting sample axis.
+   * - ``lifting_detector_mu``
+     - ``fixed_eta fixed_chi fixed_phi``
+     - All three sample-stage axes other than ``mu`` are pinned;
+       ``mu``, ``delta``, ``nu`` move.
+   * - ``lifting_detector_eta``
+     - ``fixed_mu fixed_chi fixed_phi``
+     - Equivalent of E6C ``lifting_detector_omega`` (diffcalc's
+       ``eta`` is the same physical axis as ``hkl_soleil``'s
+       ``omega``).
+   * - ``lifting_detector_phi``
+     - ``fixed_mu fixed_eta fixed_chi``
+     - Sample ``phi`` carries the motion together with the detector.
+   * - ``constant_chi`` / ``constant_phi``
+     - 2-sample-fixed modes such as ``fixed_delta fixed_chi fixed_phi``
+     - Pick the ``fixed_*`` mode whose suffix names the two sample
+       axes you want held constant plus the desired pinned detector.
+   * - ``double_diffraction``
+     - n/a in diffcalc-core
+     - diffcalc-core does not implement a double-diffraction
+       constraint; use the ``ad_hoc`` or ``hkl_soleil`` solvers for
+       that engine.
+   * - ``psi_constant``
+     - ``fixed_nu fixed_psi fixed_phi``
+     - Reference-azimuth pinned to a fixed value (here 0).
+
+The diffcalc constraint categories are documented in
+:class:`diffcalc.hkl.constraints.Constraints` (see the
+`diffcalc-core documentation <https://diffcalc-core.readthedocs.io>`_).
+A valid combination is **at most one** detector constraint, **at
+most one** reference constraint, and **one to three** sample
+constraints, totalling three constraints overall.
 
 Compute motor positions (forward)
 ---------------------------------
@@ -130,7 +189,7 @@ Available geometries at a glance
    * - :ref:`diffcalc_4S_2D <geometry.diffcalc_4S_2D>`
      - mu, delta, nu, eta, chi, phi
      - 23
-     - 4S+2D bisect_eta_fixed nu_fixed
+     - bisect fixed_mu fixed_nu
 
 .. seealso::
 

--- a/docs/source/howto_benchmark.rst
+++ b/docs/source/howto_benchmark.rst
@@ -72,7 +72,7 @@ Example output::
    Diffractometer benchmark
      solver:     diffcalc
      geometry:   diffcalc_4S_2D
-     mode:       4S+2D bisect_eta_fixed nu_fixed
+     mode:       bisect fixed_mu fixed_nu
      wavelength: 1.54
      calls:      500
 

--- a/src/hklpy2_solvers/diffcalc_solver.py
+++ b/src/hklpy2_solvers/diffcalc_solver.py
@@ -64,32 +64,32 @@ except PackageNotFoundError:  # pragma: no cover - defensive
 
 _MODES: dict[str, dict[str, Any]] = {
     # ---- 1 det + 1 ref + 1 samp ----
-    "4S+2D mu_fixed a_eq_b delta_fixed": {"delta": 0.0, "a_eq_b": True, "mu": 0.0},
-    "4S+2D mu_fixed a_eq_b nu_fixed": {"nu": 0.0, "a_eq_b": True, "mu": 0.0},
-    "4S+2D eta_fixed a_eq_b delta_fixed": {"delta": 0.0, "a_eq_b": True, "eta": 0.0},
-    "4S+2D phi_fixed psi_fixed nu_fixed": {"nu": 0.0, "psi": 0.0, "phi": 0.0},
+    "a_eq_b fixed_delta fixed_mu": {"delta": 0.0, "a_eq_b": True, "mu": 0.0},
+    "a_eq_b fixed_nu fixed_mu": {"nu": 0.0, "a_eq_b": True, "mu": 0.0},
+    "a_eq_b fixed_delta fixed_eta": {"delta": 0.0, "a_eq_b": True, "eta": 0.0},
+    "fixed_nu fixed_psi fixed_phi": {"nu": 0.0, "psi": 0.0, "phi": 0.0},
     # ---- 1 det + 2 samp ----
-    "4S+2D chi_phi_fixed delta_fixed": {"delta": 0.0, "chi": 0.0, "phi": 0.0},
-    "4S+2D mu_eta_fixed delta_fixed": {"delta": 0.0, "mu": 0.0, "eta": 0.0},
-    "4S+2D mu_phi_fixed delta_fixed": {"delta": 0.0, "mu": 0.0, "phi": 0.0},
-    "4S+2D mu_chi_fixed nu_fixed": {"nu": 0.0, "mu": 0.0, "chi": 0.0},
-    "4S+2D eta_phi_fixed nu_fixed": {"nu": 0.0, "eta": 0.0, "phi": 0.0},
-    "4S+2D eta_chi_fixed nu_fixed": {"nu": 0.0, "eta": 0.0, "chi": 0.0},
-    "4S+2D bisect_mu_fixed delta_fixed": {"delta": 0.0, "bisect": True, "mu": 0.0},
-    "4S+2D bisect_eta_fixed nu_fixed": {"nu": 0.0, "bisect": True, "eta": 0.0},
-    "4S+2D bisect_omega_fixed nu_fixed": {"nu": 0.0, "bisect": True, "omega": 0.0},
+    "fixed_delta fixed_chi fixed_phi": {"delta": 0.0, "chi": 0.0, "phi": 0.0},
+    "fixed_delta fixed_mu fixed_eta": {"delta": 0.0, "mu": 0.0, "eta": 0.0},
+    "fixed_delta fixed_mu fixed_phi": {"delta": 0.0, "mu": 0.0, "phi": 0.0},
+    "fixed_nu fixed_mu fixed_chi": {"nu": 0.0, "mu": 0.0, "chi": 0.0},
+    "fixed_nu fixed_eta fixed_phi": {"nu": 0.0, "eta": 0.0, "phi": 0.0},
+    "fixed_nu fixed_eta fixed_chi": {"nu": 0.0, "eta": 0.0, "chi": 0.0},
+    "bisect fixed_mu fixed_nu": {"bisect": True, "mu": 0.0, "nu": 0.0},
+    "bisect fixed_eta fixed_delta": {"bisect": True, "eta": 0.0, "delta": 0.0},
+    "bisect fixed_omega fixed_nu": {"bisect": True, "omega": 0.0, "nu": 0.0},
     # ---- 1 ref + 2 samp ----
-    "4S+2D chi_phi_fixed a_eq_b": {"a_eq_b": True, "chi": 0.0, "phi": 0.0},
-    "4S+2D chi_eta_fixed a_eq_b": {"a_eq_b": True, "chi": 0.0, "eta": 0.0},
-    "4S+2D chi_mu_fixed a_eq_b": {"a_eq_b": True, "chi": 0.0, "mu": 0.0},
-    "4S+2D mu_eta_fixed a_eq_b": {"a_eq_b": True, "mu": 0.0, "eta": 0.0},
-    "4S+2D mu_phi_fixed a_eq_b": {"a_eq_b": True, "mu": 0.0, "phi": 0.0},
-    "4S+2D eta_phi_fixed a_eq_b": {"a_eq_b": True, "eta": 0.0, "phi": 0.0},
+    "a_eq_b fixed_chi fixed_phi": {"a_eq_b": True, "chi": 0.0, "phi": 0.0},
+    "a_eq_b fixed_chi fixed_eta": {"a_eq_b": True, "chi": 0.0, "eta": 0.0},
+    "a_eq_b fixed_chi fixed_mu": {"a_eq_b": True, "chi": 0.0, "mu": 0.0},
+    "a_eq_b fixed_mu fixed_eta": {"a_eq_b": True, "mu": 0.0, "eta": 0.0},
+    "a_eq_b fixed_mu fixed_phi": {"a_eq_b": True, "mu": 0.0, "phi": 0.0},
+    "a_eq_b fixed_eta fixed_phi": {"a_eq_b": True, "eta": 0.0, "phi": 0.0},
     # ---- 3 samp ----
-    "4S+2D eta_chi_phi_fixed": {"eta": 0.0, "chi": 0.0, "phi": 0.0},
-    "4S+2D mu_chi_phi_fixed": {"mu": 0.0, "chi": 0.0, "phi": 0.0},
-    "4S+2D mu_eta_phi_fixed": {"mu": 0.0, "eta": 0.0, "phi": 0.0},
-    "4S+2D mu_eta_chi_fixed": {"mu": 0.0, "eta": 0.0, "chi": 0.0},
+    "fixed_eta fixed_chi fixed_phi": {"eta": 0.0, "chi": 0.0, "phi": 0.0},
+    "fixed_mu fixed_chi fixed_phi": {"mu": 0.0, "chi": 0.0, "phi": 0.0},
+    "fixed_mu fixed_eta fixed_phi": {"mu": 0.0, "eta": 0.0, "phi": 0.0},
+    "fixed_mu fixed_eta fixed_chi": {"mu": 0.0, "eta": 0.0, "chi": 0.0},
 }
 
 
@@ -134,11 +134,13 @@ class DiffcalcSolver(SolverBase):
         super().__init__(geometry, **kwargs)
 
         # Apply default mode if none was set via kwargs.
-        # Use bisect_eta_fixed nu_fixed: vertical bisector mode
-        # (eta = delta/2, eta=0, nu=0).  Equivalent to bisecting_vertical
-        # in E6C terminology.  See geometries.rst for details.
+        # bisect + mu=0 + nu=0 is the canonical bisecting_vertical
+        # (per diffcalc-core's __calc_sample_con_mu_bisect: "Vertical
+        # scattering geometry with omega = 0").  Equivalent to
+        # bisecting_vertical in hkl_soleil E6C terminology.  See
+        # geometries.rst for details.
         if not self.mode and self.modes:  # pragma: no branch
-            self.mode = "4S+2D bisect_eta_fixed nu_fixed"
+            self.mode = "bisect fixed_mu fixed_nu"
 
     # ------------------------------------------------------------------
     # Internal helpers

--- a/src/hklpy2_solvers/diffcalc_solver.py
+++ b/src/hklpy2_solvers/diffcalc_solver.py
@@ -130,6 +130,10 @@ class DiffcalcSolver(SolverBase):
         self._reflections: list[ReflectionDict] = []
         self._wavelength: float | None = None
         self._lattice: NamedFloatDict = {}
+        # User-registered modes added at runtime via register_mode().
+        # Lives for this instance only; not persisted across instances
+        # or across hklpy2 save/restore.
+        self._user_modes: dict[str, dict[str, Any]] = {}
 
         super().__init__(geometry, **kwargs)
 
@@ -150,6 +154,15 @@ class DiffcalcSolver(SolverBase):
         """Recreate the HklCalculation from current state."""
         self._hklcalc = HklCalculation(self._ubcalc, self._constraints)
 
+    def _all_modes(self) -> dict[str, dict[str, Any]]:
+        """Merged view of built-in plus user-registered modes.
+
+        Built-in modes come first; user modes follow in registration
+        order.  Built-in names cannot be shadowed (enforced by
+        :meth:`register_mode`).
+        """
+        return {**_MODES, **self._user_modes}
+
     def _apply_mode_constraints(self) -> None:
         """Set diffcalc constraints from the current mode.
 
@@ -161,7 +174,7 @@ class DiffcalcSolver(SolverBase):
             return
         if getattr(self, "_applied_mode", None) == self.mode:
             return
-        self._constraints = Constraints(_MODES[self.mode])
+        self._constraints = Constraints(self._all_modes()[self.mode])
         self._rebuild_hklcalc()
         self._applied_mode = self.mode
 
@@ -449,13 +462,17 @@ class DiffcalcSolver(SolverBase):
         check_value_in_list("Mode", value, self.modes, blank_ok=True)
         self._mode = value
         self._applied_mode = None  # invalidate so next forward() rebuilds
-        if value and value in _MODES:
+        if value and value in self._all_modes():
             self._apply_mode_constraints()
 
     @property
     def modes(self) -> list[str]:
-        """List of operating modes for this geometry."""
-        return list(_MODES.keys())
+        """List of operating modes for this geometry.
+
+        Includes both built-in modes and any user-registered modes
+        (see :meth:`register_mode`).
+        """
+        return list(self._all_modes().keys())
 
     @property
     def pseudo_axis_names(self) -> list[str]:
@@ -506,6 +523,80 @@ class DiffcalcSolver(SolverBase):
         self._rebuild_hklcalc()
         return refined
 
+    def register_mode(self, name: str, constraints: dict[str, Any]) -> None:
+        """Register a new operating mode at runtime.
+
+        Lets users add mode/constraint combinations that diffcalc-core
+        implements but ``DiffcalcSolver`` does not ship by default,
+        without forking the package.  The mode is validated against
+        :class:`diffcalc.hkl.constraints.Constraints` before being
+        accepted.
+
+        PARAMETERS
+
+        name : str
+            Name to register the mode under.  Must not clash with a
+            built-in mode name nor with a previously registered user
+            mode (use :meth:`unregister_mode` first to redefine).
+        constraints : dict[str, Any]
+            Exactly three diffcalc constraints, keyed by diffcalc
+            constraint name.  Float values pin the named axis at
+            that value; ``True`` activates a boolean constraint
+            (``a_eq_b``, ``bin_eq_bout``, ``bisect``).
+
+        RAISES
+
+        SolverError
+            If ``name`` clashes with a built-in or already-registered
+            mode; if ``constraints`` is not a dict of exactly three
+            entries with diffcalc-recognised keys; if the combination
+            does not survive ``Constraints(...).asdict`` round-trip
+            (catches same-category conflicts that diffcalc silently
+            collapses); or if
+            :meth:`diffcalc.hkl.constraints.Constraints.is_current_mode_implemented`
+            returns False.
+
+        .. note::
+
+           User-registered modes live only for the lifetime of this
+           solver instance.  They are not persisted across hklpy2
+           ``save_config`` / ``restore_config`` round-trips.
+        """
+        if not isinstance(name, str) or not name:
+            raise SolverError(f"Mode name must be a non-empty string, received {name!r}.")
+        if name in _MODES:
+            raise SolverError(f"Cannot redefine built-in mode {name!r}.")
+        if name in self._user_modes:
+            raise SolverError(f"User mode {name!r} already registered; call unregister_mode() first.")
+        if not isinstance(constraints, dict):
+            raise SolverError(f"Constraints must be a dict, received {constraints!r}.")
+        if len(constraints) != 3:
+            raise SolverError(f"Mode {name!r} requires exactly three constraints, received {len(constraints)}.")
+        try:
+            probe = Constraints(constraints)
+        except (DiffcalcException, ValueError) as exc:
+            raise SolverError(f"diffcalc rejected constraints for {name!r}: {exc}") from exc
+        # Guard against same-category collisions that diffcalc silently
+        # collapses (e.g. {delta: 0, nu: 0, mu: 0} drops delta).
+        if set(probe.asdict) != set(constraints):
+            dropped = sorted(set(constraints) - set(probe.asdict))
+            raise SolverError(
+                f"Mode {name!r}: constraints {dropped!r} were dropped by "
+                f"diffcalc (same-category conflict).  Only one detector "
+                f"and one reference constraint are allowed."
+            )
+        # ``is_current_mode_implemented()`` raises for 0/1/2-constraint
+        # Constraints objects, but those are already rejected above by
+        # the explicit ``len(constraints) != 3`` check; the bare except
+        # is defensive only.
+        try:
+            implemented = probe.is_current_mode_implemented()
+        except (DiffcalcException, ValueError) as exc:  # pragma: no cover
+            raise SolverError(f"diffcalc validation failed for {name!r}: {exc}") from exc
+        if not implemented:
+            raise SolverError(f"Mode {name!r}: constraint combination is not implemented by diffcalc-core.")
+        self._user_modes[name] = dict(constraints)
+
     def removeAllReflections(self) -> None:
         """Remove all reflections."""
         self._reflections.clear()
@@ -539,6 +630,39 @@ class DiffcalcSolver(SolverBase):
                 self._ubcalc.set_lattice("default", 1.0, 1.0, 1.0, 90.0, 90.0, 90.0)
         self._ubcalc.set_ub(value)
         self._rebuild_hklcalc()
+
+    def unregister_mode(self, name: str) -> None:
+        """Remove a previously :meth:`register_mode`-registered mode.
+
+        PARAMETERS
+
+        name : str
+            Name of the user-registered mode to remove.
+
+        RAISES
+
+        SolverError
+            If ``name`` refers to a built-in mode (built-ins cannot
+            be removed); if ``name`` is not currently registered.
+
+        If the solver-side active :attr:`mode` is the one being
+        removed, it is cleared to ``""``.  When the solver is wired
+        into an hklpy2 ``Diffractometer``, the diffractometer's own
+        cached ``core.mode`` may still hold the now-stale name and
+        cause a "Mode unknown" ``ValueError`` on the next
+        ``forward()`` call.  To avoid that, switch
+        ``diffractometer.core.mode`` to a different mode before
+        calling :meth:`unregister_mode` when the user mode is
+        currently active.
+        """
+        if name in _MODES:
+            raise SolverError(f"Cannot unregister built-in mode {name!r}.")
+        if name not in self._user_modes:
+            raise SolverError(f"User mode {name!r} is not registered.")
+        del self._user_modes[name]
+        if self.mode == name:
+            self._mode = ""
+            self._applied_mode = None
 
     @property
     def wavelength(self) -> float | None:

--- a/tests/test_cross_validation.py
+++ b/tests/test_cross_validation.py
@@ -212,7 +212,7 @@ EULER_VERTICAL_GROUP = {
         solver="diffcalc",
         geometry="diffcalc_4S_2D",
         reals=["mu", "ttheta", "nu", "omega", "chi", "phi"],
-        mode="4S+2D bisect_eta_fixed nu_fixed",
+        mode="bisect fixed_mu fixed_nu",
     ),
 }
 
@@ -295,7 +295,7 @@ EULER_HORIZONTAL_GROUP = {
         solver="diffcalc",
         geometry="diffcalc_4S_2D",
         reals=["mu", "delta", "ttheta", "omega", "chi", "phi"],
-        mode="4S+2D mu_fixed a_eq_b delta_fixed",
+        mode="a_eq_b fixed_delta fixed_mu",
     ),
 }
 

--- a/tests/test_diffcalc_solver.py
+++ b/tests/test_diffcalc_solver.py
@@ -24,7 +24,7 @@ TTH_100 = 2 * THETA_100
 
 
 def _make_solver_with_ub(
-    mode: str = "4S+2D mu_chi_phi_fixed",
+    mode: str = "fixed_mu fixed_chi fixed_phi",
 ) -> DiffcalcSolver:
     """Return a DiffcalcSolver with Si lattice, two reflections, and UB calculated."""
     solver = DiffcalcSolver()
@@ -114,12 +114,12 @@ def test_class_attributes(parms, context):
     "parms, context",
     [
         pytest.param(
-            dict(mode="4S+2D mu_chi_phi_fixed"),
+            dict(mode="fixed_mu fixed_chi fixed_phi"),
             does_not_raise(),
             id="valid mode accepted",
         ),
         pytest.param(
-            dict(mode="4S+2D eta_chi_phi_fixed"),
+            dict(mode="fixed_eta fixed_chi fixed_phi"),
             does_not_raise(),
             id="another valid mode",
         ),
@@ -384,7 +384,7 @@ def test_calculate_ub_honours_arguments(parms, context):
     [
         pytest.param(
             dict(
-                mode="4S+2D mu_chi_phi_fixed",
+                mode="fixed_mu fixed_chi fixed_phi",
                 pseudos={"h": 1.0, "k": 0.0, "l": 0.0},
                 expected_h=1.0,
                 expected_k=0.0,
@@ -395,7 +395,7 @@ def test_calculate_ub_honours_arguments(parms, context):
         ),
         pytest.param(
             dict(
-                mode="4S+2D eta_chi_phi_fixed",
+                mode="fixed_eta fixed_chi fixed_phi",
                 pseudos={"h": 0.0, "k": 1.0, "l": 0.0},
                 expected_h=0.0,
                 expected_k=1.0,
@@ -406,7 +406,7 @@ def test_calculate_ub_honours_arguments(parms, context):
         ),
         pytest.param(
             dict(
-                mode="4S+2D mu_chi_phi_fixed",
+                mode="fixed_mu fixed_chi fixed_phi",
                 pseudos="not a dict",
                 expected_h=0,
                 expected_k=0,
@@ -488,7 +488,7 @@ def test_inverse(parms, context):
     [
         pytest.param(
             dict(
-                mode="4S+2D mu_chi_phi_fixed",
+                mode="fixed_mu fixed_chi fixed_phi",
                 pseudos={"h": 1.0, "k": 0.0, "l": 0.0},
             ),
             does_not_raise(),
@@ -496,7 +496,7 @@ def test_inverse(parms, context):
         ),
         pytest.param(
             dict(
-                mode="4S+2D mu_chi_phi_fixed",
+                mode="fixed_mu fixed_chi fixed_phi",
                 pseudos={"h": 0.0, "k": 1.0, "l": 0.0},
             ),
             does_not_raise(),
@@ -504,7 +504,7 @@ def test_inverse(parms, context):
         ),
         pytest.param(
             dict(
-                mode="4S+2D mu_chi_phi_fixed",
+                mode="fixed_mu fixed_chi fixed_phi",
                 pseudos={"h": 1.0, "k": 1.0, "l": 0.0},
             ),
             does_not_raise(),
@@ -529,12 +529,12 @@ def test_forward_inverse_roundtrip(parms, context):
     "parms, context",
     [
         pytest.param(
-            dict(mode="4S+2D mu_chi_phi_fixed"),
+            dict(mode="fixed_mu fixed_chi fixed_phi"),
             does_not_raise(),
             id="extra_axis_names is always empty",
         ),
         pytest.param(
-            dict(mode="4S+2D mu_fixed a_eq_b delta_fixed"),
+            dict(mode="a_eq_b fixed_delta fixed_mu"),
             does_not_raise(),
             id="extra_axis_names empty for det+ref+samp mode",
         ),
@@ -558,7 +558,7 @@ def test_extra_axis_names(parms, context):
     [
         pytest.param(
             dict(
-                mode="4S+2D mu_chi_phi_fixed",
+                mode="fixed_mu fixed_chi fixed_phi",
                 expected_axes_w=["delta", "nu", "eta"],
             ),
             does_not_raise(),
@@ -566,7 +566,7 @@ def test_extra_axis_names(parms, context):
         ),
         pytest.param(
             dict(
-                mode="4S+2D mu_fixed a_eq_b delta_fixed",
+                mode="a_eq_b fixed_delta fixed_mu",
                 expected_axes_w=["nu", "eta", "chi", "phi"],
             ),
             does_not_raise(),
@@ -574,7 +574,7 @@ def test_extra_axis_names(parms, context):
         ),
         pytest.param(
             dict(
-                mode="4S+2D chi_phi_fixed delta_fixed",
+                mode="fixed_delta fixed_chi fixed_phi",
                 expected_axes_w=["mu", "nu", "eta"],
             ),
             does_not_raise(),
@@ -748,7 +748,7 @@ def test_lattice_preserved_after_reset(parms, context):
     [
         pytest.param(
             dict(
-                mode="4S+2D mu_chi_phi_fixed",
+                mode="fixed_mu fixed_chi fixed_phi",
                 pseudos={"h": 1, "k": 0, "l": 0},
                 min_solutions=1,
             ),
@@ -793,7 +793,7 @@ def test_refine_lattice_insufficient_reflections(parms, context):
     [
         pytest.param(
             dict(
-                mode="4S+2D mu_fixed a_eq_b delta_fixed",
+                mode="a_eq_b fixed_delta fixed_mu",
                 pseudos={"h": 100, "k": 100, "l": 100},
             ),
             pytest.raises(Exception, match=re.escape("Reflection unreachable")),
@@ -828,7 +828,7 @@ def test_refine_lattice_success(parms, context):
     # For cubic Si, d_hkl = a/sqrt(h^2+k^2+l^2).
     # Bragg: theta = arcsin(wl/(2*d))
     # Compute angles using mu_chi_phi_fixed mode from a helper solver.
-    helper = _make_solver_with_ub(mode="4S+2D mu_chi_phi_fixed")
+    helper = _make_solver_with_ub(mode="fixed_mu fixed_chi fixed_phi")
 
     # (1,0,0) and (0,1,0) work fine with this mode.
     # (1,1,0) also works. All are in-plane with chi=phi=mu=0.
@@ -1135,7 +1135,7 @@ def test_ub_setter(parms, context):
     "parms, context",
     [
         pytest.param(
-            dict(mode="4S+2D mu_chi_phi_fixed", pseudos={"h": 1.0, "k": 0.0, "l": 0.0}),
+            dict(mode="fixed_mu fixed_chi fixed_phi", pseudos={"h": 1.0, "k": 0.0, "l": 0.0}),
             does_not_raise(),
             id="forward succeeds after update_solver restores UB via setter - issue #29",
         ),
@@ -1164,7 +1164,7 @@ def test_forward_after_ub_restore(parms, context):
         # -- 1 det + 1 ref + 1 samp (a_eq_b is non-motor) --
         pytest.param(
             dict(
-                mode="4S+2D mu_fixed a_eq_b delta_fixed",
+                mode="a_eq_b fixed_delta fixed_mu",
                 expected_reals=["nu", "eta", "chi", "phi"],
             ),
             does_not_raise(),
@@ -1173,7 +1173,7 @@ def test_forward_after_ub_restore(parms, context):
         # -- 1 det + 1 ref + 1 samp (psi is non-motor) --
         pytest.param(
             dict(
-                mode="4S+2D phi_fixed psi_fixed nu_fixed",
+                mode="fixed_nu fixed_psi fixed_phi",
                 expected_reals=["mu", "delta", "eta", "chi"],
             ),
             does_not_raise(),
@@ -1182,7 +1182,7 @@ def test_forward_after_ub_restore(parms, context):
         # -- 1 det + 2 samp --
         pytest.param(
             dict(
-                mode="4S+2D chi_phi_fixed delta_fixed",
+                mode="fixed_delta fixed_chi fixed_phi",
                 expected_reals=["mu", "nu", "eta"],
             ),
             does_not_raise(),
@@ -1191,16 +1191,16 @@ def test_forward_after_ub_restore(parms, context):
         # -- 1 det + 2 samp (bisect is non-motor) --
         pytest.param(
             dict(
-                mode="4S+2D bisect_mu_fixed delta_fixed",
-                expected_reals=["nu", "eta", "chi", "phi"],
+                mode="bisect fixed_mu fixed_nu",
+                expected_reals=["delta", "eta", "chi", "phi"],
             ),
             does_not_raise(),
-            id="bisect non-motor: only mu,delta fixed",
+            id="bisect vertical: mu,nu fixed",
         ),
         # -- 1 det + 2 samp (bisect+omega are non-motor) --
         pytest.param(
             dict(
-                mode="4S+2D bisect_omega_fixed nu_fixed",
+                mode="bisect fixed_omega fixed_nu",
                 expected_reals=["mu", "delta", "eta", "chi", "phi"],
             ),
             does_not_raise(),
@@ -1209,7 +1209,7 @@ def test_forward_after_ub_restore(parms, context):
         # -- 1 ref + 2 samp --
         pytest.param(
             dict(
-                mode="4S+2D chi_mu_fixed a_eq_b",
+                mode="a_eq_b fixed_chi fixed_mu",
                 expected_reals=["delta", "nu", "eta", "phi"],
             ),
             does_not_raise(),
@@ -1218,7 +1218,7 @@ def test_forward_after_ub_restore(parms, context):
         # -- 3 samp --
         pytest.param(
             dict(
-                mode="4S+2D eta_chi_phi_fixed",
+                mode="fixed_eta fixed_chi fixed_phi",
                 expected_reals=["mu", "delta", "nu"],
             ),
             does_not_raise(),
@@ -1226,7 +1226,7 @@ def test_forward_after_ub_restore(parms, context):
         ),
         pytest.param(
             dict(
-                mode="4S+2D mu_eta_chi_fixed",
+                mode="fixed_mu fixed_eta fixed_chi",
                 expected_reals=["delta", "nu", "phi"],
             ),
             does_not_raise(),
@@ -1451,3 +1451,104 @@ def test_ub_setter_default_lattice(parms, context):
     with context:
         solver.UB = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
         assert solver._ubcalc.crystal is not None
+
+
+# ---------------------------------------------------------------------------
+# Rename completeness (issues #97, #105): guards the Proposal A naming rules.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(name="4S+2D bisect_eta_fixed nu_fixed"),
+            pytest.raises(ValueError, match=re.escape("Mode")),
+            id="old-style name with 4S+2D prefix rejected",
+        ),
+        pytest.param(
+            dict(name="fixed_mu fixed_chi fixed_phi"),
+            does_not_raise(),
+            id="new-style all-fixed_* name accepted",
+        ),
+        pytest.param(
+            dict(name="bisect fixed_mu fixed_nu"),
+            does_not_raise(),
+            id="new-style bisect-led name accepted (canonical vertical bisector)",
+        ),
+        pytest.param(
+            dict(name="a_eq_b fixed_delta fixed_mu"),
+            does_not_raise(),
+            id="new-style a_eq_b-led name accepted",
+        ),
+    ],
+)
+def test_mode_rename_completeness(parms, context):
+    """Pin the post-rename mode-name conventions.
+
+    Old-style names containing the ``4S+2D`` prefix or the
+    ``<axis>_fixed`` suffix are not part of ``_MODES`` any more and
+    must be rejected by the mode setter.  New-style names matching
+    Proposal A (drop prefix, ``fixed_<axis>`` form, keyword
+    constraints first) must be accepted.
+    """
+    solver = DiffcalcSolver()
+    with context:
+        solver.mode = parms["name"]
+        assert solver.mode == parms["name"]
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(check="no 4S+2D prefix"),
+            does_not_raise(),
+            id="no mode name contains the 4S+2D prefix",
+        ),
+        pytest.param(
+            dict(check="no <axis>_fixed suffix"),
+            does_not_raise(),
+            id="no mode name contains the legacy <axis>_fixed suffix",
+        ),
+        pytest.param(
+            dict(check="keyword constraints lead"),
+            does_not_raise(),
+            id="modes with a_eq_b/bisect/bin_eq_bout lead with that token",
+        ),
+        pytest.param(
+            dict(check="default is canonical bisecting_vertical"),
+            does_not_raise(),
+            id="default mode is bisect fixed_mu fixed_nu",
+        ),
+    ],
+)
+def test_mode_naming_invariants(parms, context):
+    """Static checks on the entire ``_MODES`` table.
+
+    These invariants are guarded as tests so a future PR that adds a
+    new mode in the old style (or moves a keyword token off the
+    leading position) trips immediately, rather than silently
+    re-introducing the inconsistency #97 set out to fix.
+    """
+    keywords = {"a_eq_b", "bisect", "bin_eq_bout"}
+    with context:
+        check = parms["check"]
+        if check == "no 4S+2D prefix":
+            assert not any("4S+2D" in name for name in _MODES)
+        elif check == "no <axis>_fixed suffix":
+            offenders = [name for name in _MODES if re.search(r"\b[a-z]+_fixed\b", name)]
+            assert offenders == []
+        elif check == "keyword constraints lead":
+            for name in _MODES:
+                toks = name.split()
+                kw_positions = [i for i, t in enumerate(toks) if t in keywords]
+                if not kw_positions:
+                    continue
+                assert kw_positions == list(range(len(kw_positions))), (
+                    f"mode {name!r}: keyword tokens must come first"
+                )
+        elif check == "default is canonical bisecting_vertical":
+            solver = DiffcalcSolver()
+            assert solver.mode == "bisect fixed_mu fixed_nu"
+            assert _MODES[solver.mode] == {"bisect": True, "mu": 0.0, "nu": 0.0}

--- a/tests/test_diffcalc_solver.py
+++ b/tests/test_diffcalc_solver.py
@@ -1552,3 +1552,217 @@ def test_mode_naming_invariants(parms, context):
             solver = DiffcalcSolver()
             assert solver.mode == "bisect fixed_mu fixed_nu"
             assert _MODES[solver.mode] == {"bisect": True, "mu": 0.0, "nu": 0.0}
+
+
+# ---------------------------------------------------------------------------
+# Runtime mode registration (issues #97, #106): register_mode / unregister_mode
+# fill gaps where diffcalc-core implements a constraint combination that
+# DiffcalcSolver does not ship by default.
+# ---------------------------------------------------------------------------
+
+
+# A combination diffcalc-core implements but ``_MODES`` does not ship.
+# ``{delta: 0, eta: 0, chi: 0}`` is the delta-pinned cousin of the
+# nu-pinned ``fixed_nu fixed_eta fixed_chi`` built-in (eta&chi sample
+# pair + delta detector pin); is_current_mode_implemented() returns True.
+RUNTIME_MODE_NAME = "fixed_delta fixed_eta fixed_chi"
+RUNTIME_MODE_CONSTRAINTS = {"delta": 0.0, "eta": 0.0, "chi": 0.0}
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(
+                name=RUNTIME_MODE_NAME,
+                constraints=RUNTIME_MODE_CONSTRAINTS,
+            ),
+            does_not_raise(),
+            id="register a valid not-shipped combination",
+        ),
+        pytest.param(
+            dict(
+                name="bisect fixed_mu fixed_nu",
+                constraints={"bisect": True, "mu": 0.0, "nu": 0.0},
+            ),
+            pytest.raises(SolverError, match=re.escape("Cannot redefine built-in mode")),
+            id="reject clash with built-in mode name",
+        ),
+        pytest.param(
+            dict(
+                name="",
+                constraints=RUNTIME_MODE_CONSTRAINTS,
+            ),
+            pytest.raises(SolverError, match=re.escape("non-empty string")),
+            id="reject empty name",
+        ),
+        pytest.param(
+            dict(
+                name=123,
+                constraints=RUNTIME_MODE_CONSTRAINTS,
+            ),
+            pytest.raises(SolverError, match=re.escape("non-empty string")),
+            id="reject non-string name",
+        ),
+        pytest.param(
+            dict(
+                name="bad_not_dict",
+                constraints=[("delta", 0.0), ("eta", 0.0), ("chi", 0.0)],
+            ),
+            pytest.raises(SolverError, match=re.escape("must be a dict")),
+            id="reject non-dict constraints",
+        ),
+        pytest.param(
+            dict(
+                name="bad_two",
+                constraints={"delta": 0.0, "eta": 0.0},
+            ),
+            pytest.raises(SolverError, match=re.escape("exactly three constraints")),
+            id="reject 2-constraint dict",
+        ),
+        pytest.param(
+            dict(
+                name="bad_four",
+                constraints={"delta": 0.0, "eta": 0.0, "chi": 0.0, "phi": 0.0},
+            ),
+            pytest.raises(SolverError, match=re.escape("exactly three constraints")),
+            id="reject 4-constraint dict",
+        ),
+        pytest.param(
+            dict(
+                name="bad_unknown",
+                constraints={"bogus": 0.0, "mu": 0.0, "phi": 0.0},
+            ),
+            pytest.raises(SolverError, match=re.escape("diffcalc rejected constraints")),
+            id="reject unknown constraint name",
+        ),
+        pytest.param(
+            dict(
+                name="bad_two_detector",
+                constraints={"delta": 0.0, "nu": 0.0, "mu": 0.0},
+            ),
+            pytest.raises(SolverError, match=re.escape("dropped by diffcalc (same-category conflict)")),
+            id="reject same-category collision (two detectors)",
+        ),
+        pytest.param(
+            dict(
+                name="bad_not_implemented",
+                constraints={"mu": 0.0, "chi": 0.0, "omega": 0.0},
+            ),
+            pytest.raises(SolverError, match=re.escape("not implemented by diffcalc-core")),
+            id="reject structurally-valid but not-implemented combination",
+        ),
+        pytest.param(
+            dict(
+                name=RUNTIME_MODE_NAME,
+                constraints=RUNTIME_MODE_CONSTRAINTS,
+                preregister=True,
+            ),
+            pytest.raises(SolverError, match=re.escape("already registered")),
+            id="reject duplicate registration of an existing user mode",
+        ),
+    ],
+)
+def test_register_mode(parms, context):
+    """Cover register_mode happy path and every rejection path.
+
+    Validates the runtime mode-registration contract:
+
+    * Valid not-shipped combinations are accepted and become
+      selectable via the merged ``modes`` list.
+    * Built-in mode names cannot be shadowed.
+    * Inputs are validated for type and count before being passed
+      to diffcalc, so error messages stay actionable.
+    * Same-category collisions silently collapsed by diffcalc
+      (e.g. two detector constraints) are rejected explicitly,
+      naming the dropped keys.
+    * Combinations that survive structural validation but lack a
+      diffcalc implementation (``is_current_mode_implemented()``
+      returns False) are rejected.
+    """
+    solver = DiffcalcSolver()
+    if parms.get("preregister"):
+        solver.register_mode(parms["name"], parms["constraints"])
+    with context:
+        solver.register_mode(parms["name"], parms["constraints"])
+        assert parms["name"] in solver.modes
+        # Verify selectability and that the active mode round-trips.
+        solver.mode = parms["name"]
+        assert solver.mode == parms["name"]
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(name=RUNTIME_MODE_NAME, preselect=False),
+            does_not_raise(),
+            id="unregister a previously registered user mode",
+        ),
+        pytest.param(
+            dict(name=RUNTIME_MODE_NAME, preselect=True),
+            does_not_raise(),
+            id="unregister the currently selected mode clears self.mode",
+        ),
+        pytest.param(
+            dict(name="bisect fixed_mu fixed_nu", preselect=False),
+            pytest.raises(SolverError, match=re.escape("Cannot unregister built-in mode")),
+            id="reject unregister of built-in",
+        ),
+        pytest.param(
+            dict(name="never_registered", preselect=False),
+            pytest.raises(SolverError, match=re.escape("is not registered")),
+            id="reject unregister of missing user mode",
+        ),
+    ],
+)
+def test_unregister_mode(parms, context):
+    """Cover unregister_mode happy path and rejection paths.
+
+    Confirms that built-in modes cannot be removed; that a request
+    to remove a never-registered mode is rejected; and that
+    removing the currently-selected mode clears the active mode so
+    subsequent forward() calls don't silently re-use the dropped
+    constraints.
+    """
+    solver = DiffcalcSolver()
+    # Always register the runtime mode so the happy-path cases have
+    # something to remove; built-in/missing cases ignore it.
+    solver.register_mode(RUNTIME_MODE_NAME, RUNTIME_MODE_CONSTRAINTS)
+    if parms["preselect"]:
+        solver.mode = parms["name"]
+    with context:
+        solver.unregister_mode(parms["name"])
+        assert parms["name"] not in solver.modes
+        if parms["preselect"]:
+            assert solver.mode == ""
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(
+                name=RUNTIME_MODE_NAME,
+                constraints=RUNTIME_MODE_CONSTRAINTS,
+            ),
+            does_not_raise(),
+            id="user-registered mode is usable end-to-end",
+        ),
+    ],
+)
+def test_register_mode_end_to_end(parms, context):
+    """A registered user mode is selectable and drives inverse() / forward().
+
+    Confirms the merged-mode path through ``_apply_mode_constraints`` —
+    proving that ``register_mode`` is not just bookkeeping but actually
+    feeds the diffcalc ``Constraints`` object used by the calculator.
+    """
+    with context:
+        # Build a solver with UB *before* registering, then switch into
+        # the user mode and exercise inverse() at the origin.
+        solver = _make_solver_with_ub()
+        solver.register_mode(parms["name"], parms["constraints"])
+        solver.mode = parms["name"]
+        result = solver.inverse({"mu": 0.0, "delta": 0.0, "nu": 0.0, "eta": 0.0, "chi": 0.0, "phi": 0.0})
+        assert set(result) == {"h", "k", "l"}


### PR DESCRIPTION
- closes #97
- closes #105
- closes #106
- relates #108

Implements **Proposal A** decided in #97: drop the `4S+2D` prefix,
use `fixed_<axis>` for value-pinned constraints, lead each mode
name with keyword constraints (`a_eq_b`, `bisect`, `bin_eq_bout`)
where present.  Hard break, no deprecation shim.

Bisect realignment
------------------

While reviewing the rename, the original `_MODES` table was found
to mis-pair the two non-`omega` bisect modes against the diffcalc
source comments in `__calc_sample_con_mu_bisect` ("Vertical
scattering geometry with omega = 0") and
`__calc_sample_con_eta_bisect` ("Horizontal scattering geometry
with omega = 0").  The canonical pairings are now:

| Mode | Family | Pinned | Active |
|---|---|---|---|
| `bisect fixed_mu fixed_nu` | bisecting vertical | mu=0, nu=0 | delta (ttheta) + eta (ttheta/2) |
| `bisect fixed_eta fixed_delta` | bisecting horizontal | eta=0, delta=0 | nu (ttheta) + mu (ttheta/2) |
| `bisect fixed_omega fixed_nu` | omega-tilt | omega=0, nu=0 | mu + eta + delta |

The two prior off-pairing combos are removed.  Default mode is
now `bisect fixed_mu fixed_nu` (canonical `bisecting_vertical`).

Runtime mode registration (#106)
--------------------------------

Folded in per maintainer request: new public methods
`DiffcalcSolver.register_mode(name, constraints)` and
`DiffcalcSolver.unregister_mode(name)` let users add constraint
combinations that diffcalc-core implements but the package does
not ship by default, without forking.

Validation rejects: name clashes with built-ins, duplicate
registrations, malformed inputs (non-string/empty name, non-dict
constraints, wrong constraint count), unknown constraint names,
same-category collisions silently collapsed by diffcalc (named
in the error), and combinations whose
`is_current_mode_implemented()` returns False.

User modes live for the solver instance lifetime only; persistence
through hklpy2 `export`/`restore`/`simulator_from_config`
requires an upstream schema addition tracked in #108 (covers
both this case and the analogous AdHocSolver registered-geometry
case).

Docs
----

* `geometries.rst`: renamed mode table, new bisecting-mode table,
  rewritten naming-convention section, updated default-mode prose.
* `guide_diffcalc.rst`: Cross-reference to common conventions
  section; new 'Register a runtime mode' section with worked
  example and persistence-caveat callout linking #108.
* `howto_benchmark.rst`, `docs/source/_static/diffcalc_4s_2d.yml`:
  rename literals.

Tests
-----

* All 23 mode literals across `test_diffcalc_solver.py` and
  `test_cross_validation.py` renamed.
* 8 parametrised cases pin the post-rename invariants.
* 15 parametrised cases cover register_mode / unregister_mode
  happy paths and every rejection path, plus an end-to-end
  round-trip through `inverse()`.

Quality gates
-------------

* `pre-commit run --all-files`: clean.
* `pytest ./tests`: 916 passed, 34 xfailed, 6 xpassed.
* `coverage report`: 100.000% (line + branch), `fail_under = 100`.
* `sphinx-build -W`: clean.

Out of scope
------------

* Round-trip persistence of user modes through hklpy2 config
  export/restore -- tracked in #108 (requires upstream change).

Agent: OpenCode (argo/claudeopus47)