### PR TITLE
maint #112 unify copyright automation

### DIFF
--- a/.copyright.txt
+++ b/.copyright.txt
@@ -1,2 +1,2 @@
-Copyright (c) 2026 Pete Jemian <prjemian+hklpy2@gmail.com>
+Copyright (c) 2025-2026 UChicago Argonne, LLC
 SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,21 @@ repos:
           - --license-filepath=.copyright.txt
           - --comment-style=#
           - --no-extra-eol
+      - id: insert-license
+        name: insert-license (scripts)
+        files: ^scripts/.*\.py$
+        args:
+          - --license-filepath=.copyright.txt
+          - --comment-style=#
+          - --no-extra-eol
+  - repo: local
+    hooks:
+      - id: update-copyright-year
+        name: Update copyright end year
+        language: python
+        entry: python scripts/update_copyright_year.py
+        pass_filenames: false
+        always_run: true
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.12
     hooks:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,71 @@ PRs opened or modified by automated agents must follow the "Agent pytest style" 
 - Inputs: file diffs, test results, config files, repository metadata
 - Outputs: patch/commit, tests, updated docs, CI status
 
+## Copyright handling
+
+The repo uses three coordinated mechanisms to keep copyright text
+consistent.  All three are wired into pre-commit and run automatically.
+
+### 1. Per-file headers — `.copyright.txt` + `insert-license`
+
+`.copyright.txt` is the single source of truth for the per-file header
+text:
+
+```text
+Copyright (c) 2025-2026 UChicago Argonne, LLC
+SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
+```
+
+The `Lucas-C/insert-license` pre-commit hook propagates that header to
+every covered Python file on each commit.  Three hook instances cover:
+
+- `src/hklpy2_solvers/*.py` (excluding `_version.py`)
+- `tests/test_*.py`
+- `scripts/*.py`
+
+To change the per-file header text project-wide, edit only
+`.copyright.txt` and run `pre-commit run --all-files`.
+
+### 2. Year-range bump — `scripts/update_copyright_year.py`
+
+A **local** pre-commit hook (`update-copyright-year`) runs the
+`scripts/update_copyright_year.py` script on every commit.  The script
+rewrites the pattern `<START>-<OLD_END>` → `<START>-<CURRENT_YEAR>` in
+each file listed in its `TARGET_FILES`:
+
+- `.copyright.txt`
+- `LICENSE` (line 1 only — the licence body is verbatim per ANL legal
+  and is never edited)
+- `docs/source/conf.py`
+
+The script exits non-zero when it changes anything, so pre-commit fails
+and the developer stages the rewrite before retrying the commit.  On
+January 1 of any year, the next commit on any branch will bring every
+year span forward.
+
+### 3. Sphinx docs — static year range in `conf.py`
+
+`docs/source/conf.py` declares `copyright` as a static year-range string,
+not a build-time-dynamic `datetime.now().year` expression.  This is
+intentional: the bump script is the single mechanism that keeps
+`LICENSE`, `.copyright.txt`, and the rendered docs aligned, and a
+dynamic expression would hide drift between them.
+
+### What NOT to edit by hand
+
+- The `Copyright (c) YYYY-YYYY ...` line on individual `.py` files —
+  edit `.copyright.txt` and re-run pre-commit instead.
+- The end year in `LICENSE` line 1, `docs/source/conf.py`, or
+  `.copyright.txt` on January 1 — the bump script handles it.
+- The body of `LICENSE` — verbatim per ANL legal.
+
+### What to edit by hand
+
+- The **start** year in any year range (project inception year);
+  the script never touches it.
+- Adding new files to `TARGET_FILES` if a new file legitimately
+  contains a year range.
+
 ## Running locally
 
 - Setup: create virtualenv, `pip install -e .[all]`

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -29,6 +29,11 @@ describe future plans.
 
     Expected release: tba
 
+    Maintenance
+    ~~~~~~~~~~~
+
+    * Unify copyright automation across hklpy2 family.  :issue:`112`
+
 0.3.3
 ######
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -7,7 +7,6 @@ import os
 import pathlib
 import sys
 import tomllib
-from datetime import datetime
 from importlib.metadata import version as _version
 
 root_path = pathlib.Path(__file__).parent.parent.parent
@@ -21,7 +20,9 @@ sys.path.insert(0, str(root_path / "src"))
 
 project = _toml["project"]["name"]
 author = _toml["project"]["authors"][0]["name"]
-copyright = f"2025-{datetime.now().year}, Argonne National Laboratory"
+# Static year range; kept in sync with .copyright.txt and LICENSE by
+# scripts/update_copyright_year.py (registered as a pre-commit hook).
+copyright = "2025-2026, UChicago Argonne, LLC"
 github_url = _toml["project"]["urls"]["source"]
 
 release = _version("hklpy2-solvers")

--- a/scripts/stamp_release.py
+++ b/scripts/stamp_release.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2026 Pete Jemian <prjemian+hklpy2@gmail.com>
+# Copyright (c) 2025-2026 UChicago Argonne, LLC
 # SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Prepare RELEASE_NOTES.rst for a new tagged release.

--- a/scripts/update_copyright_year.py
+++ b/scripts/update_copyright_year.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
+"""
+Update the copyright end year in tracked source files to the current year.
+
+Designed to be used as a pre-commit hook (local repo hook).  Exit codes follow
+the pre-commit convention:
+
+* 0 - nothing changed (all files already have the correct year).
+* 1 - one or more files were modified; pre-commit will mark the hook as
+      "failed" so the developer sees the diff and stages the updated files
+      before retrying the commit.
+
+The script rewrites the pattern ``<START_YEAR>-<OLD_YEAR>`` ->
+``<START_YEAR>-<CURRENT_YEAR>`` wherever it appears in each target file,
+leaving everything else untouched.
+
+Files checked (paths relative to the repository root):
+
+* ``.copyright.txt``          - per-file header template
+* ``LICENSE``                 - line-1 copyright statement (only the year
+                                range is rewritten; the licence body is
+                                verbatim per ANL legal and is never touched
+                                by this script)
+* ``docs/source/conf.py``     - Sphinx ``copyright`` value
+
+To add a new target, append to :data:`TARGET_FILES` below.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+from datetime import datetime
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = pathlib.Path(__file__).parent.parent
+
+# Files that contain the copyright year span, relative to the repo root.
+TARGET_FILES: list[pathlib.Path] = [
+    REPO_ROOT / ".copyright.txt",
+    REPO_ROOT / "LICENSE",
+    REPO_ROOT / "docs" / "source" / "conf.py",
+]
+
+# Matches e.g. "2026-2026" and captures the start year and old end year.
+YEAR_RANGE_PATTERN = re.compile(r"(\d{4})-(\d{4})")
+
+CURRENT_YEAR = str(datetime.now().year)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def update_file(path: pathlib.Path, current_year: str) -> bool:
+    """
+    Replace stale end-years in *path* with *current_year*.
+
+    Returns True if the file was modified.
+    """
+    original = path.read_text(encoding="utf-8")
+
+    def _replace(match: re.Match) -> str:
+        start, end = match.group(1), match.group(2)
+        if end == current_year:
+            return match.group(0)  # already up to date
+        return f"{start}-{current_year}"
+
+    updated = YEAR_RANGE_PATTERN.sub(_replace, original)
+
+    if updated == original:
+        return False
+
+    path.write_text(updated, encoding="utf-8")
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    changed: list[pathlib.Path] = []
+
+    for filepath in TARGET_FILES:
+        if not filepath.exists():
+            print(f"WARNING: {filepath} not found - skipping.", file=sys.stderr)
+            continue
+        if update_file(filepath, CURRENT_YEAR):
+            changed.append(filepath)
+            print(f"Updated copyright end year to {CURRENT_YEAR} in: {filepath.relative_to(REPO_ROOT)}")
+
+    if changed:
+        print(
+            "\nCopyright year(s) updated. Stage the changed file(s) and re-run the commit.",
+            file=sys.stderr,
+        )
+        return 1  # signal pre-commit that something changed
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/hklpy2_solvers/__init__.py
+++ b/src/hklpy2_solvers/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Pete Jemian <prjemian+hklpy2@gmail.com>
+# Copyright (c) 2025-2026 UChicago Argonne, LLC
 # SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """Solvers for the hklpy2 package."""
 

--- a/src/hklpy2_solvers/ad_hoc_solver.py
+++ b/src/hklpy2_solvers/ad_hoc_solver.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Pete Jemian <prjemian+hklpy2@gmail.com>
+# Copyright (c) 2025-2026 UChicago Argonne, LLC
 # SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Solver wrapping *ad_hoc_diffractometer* for hklpy2.

--- a/src/hklpy2_solvers/diffcalc_solver.py
+++ b/src/hklpy2_solvers/diffcalc_solver.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Pete Jemian <prjemian+hklpy2@gmail.com>
+# Copyright (c) 2025-2026 UChicago Argonne, LLC
 # SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """
 Solver wrapping *diffcalc-core* for hklpy2.

--- a/tests/test_ad_hoc_solver.py
+++ b/tests/test_ad_hoc_solver.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Pete Jemian <prjemian+hklpy2@gmail.com>
+# Copyright (c) 2025-2026 UChicago Argonne, LLC
 # SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """Tests for the ad_hoc solver adapter."""
 

--- a/tests/test_cross_validation.py
+++ b/tests/test_cross_validation.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Pete Jemian <prjemian+hklpy2@gmail.com>
+# Copyright (c) 2025-2026 UChicago Argonne, LLC
 # SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """Cross-validate solver geometries against ``hkl_soleil`` (libhkl).
 

--- a/tests/test_diffcalc_solver.py
+++ b/tests/test_diffcalc_solver.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Pete Jemian <prjemian+hklpy2@gmail.com>
+# Copyright (c) 2025-2026 UChicago Argonne, LLC
 # SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """Tests for the diffcalc solver adapter."""
 

--- a/tests/test_docs_guides.py
+++ b/tests/test_docs_guides.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Pete Jemian <prjemian+hklpy2@gmail.com>
+# Copyright (c) 2025-2026 UChicago Argonne, LLC
 # SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """Guide-regression smoke test (:issue:`88`).
 

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026 Pete Jemian <prjemian+hklpy2@gmail.com>
+# Copyright (c) 2025-2026 UChicago Argonne, LLC
 # SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
 """Basic package tests."""
 


### PR DESCRIPTION
- closes #112

## Summary

Port the unified copyright-automation system finalised in
BCDA-APS/ad_hoc_diffractometer#291 (which closes BCDA-APS/ad_hoc_diffractometer#290) to this repo.

## Changes

### Configuration
- `.copyright.txt`: range form `2025-2026`, holder switched from
  personal name/email to `UChicago Argonne, LLC`.  SPDX identifier
  unchanged (`LicenseRef-UChicago-Argonne-LLC-License`).
- `LICENSE`: line 1 already `2025-2026, UChicago Argonne, LLC`; no
  change needed.
- `docs/source/conf.py`: replaced
  `copyright = f"2025-{datetime.now().year}, Argonne National Laboratory"`
  with static `"2025-2026, UChicago Argonne, LLC"`.  Bump script
  maintains the end year.  Dropped unused `datetime` import.

### New: bump script and hook
- `scripts/update_copyright_year.py`: ported from BCDA-APS/ad_hoc_diffractometer#291.  Rewrites
  `<START>-<OLD_END>` → `<START>-<CURRENT_YEAR>` in
  `TARGET_FILES = [.copyright.txt, LICENSE, docs/source/conf.py]`.
  Exits non-zero on change so pre-commit fails until the developer
  stages the rewrite.
- `.pre-commit-config.yaml`:
  - New local hook `update-copyright-year`
    (`always_run: true`, `pass_filenames: false`).
  - New `insert-license (scripts)` instance covering `scripts/*.py`
    (covers `scripts/stamp_release.py` and the new bump script).

### Header propagation
- All 9 covered `.py` files had their personal-attribution header
  (`Pete Jemian <prjemian+hklpy2@gmail.com>`) replaced by the
  institutional header from the new `.copyright.txt`.  Bulk diff;
  no logic changed.
- Personal attribution is preserved in `pyproject.toml`
  `authors` / `maintainers`.

### Documentation
- `AGENTS.md`: new "Copyright handling" section explaining the three
  coordinated mechanisms (`.copyright.txt` + `insert-license`, the
  bump script, static Sphinx `conf.py`), what to edit by hand, and
  what not to.  Mirrors the wording added to
  ad_hoc_diffractometer in BCDA-APS/ad_hoc_diffractometer#291.
- `RELEASE_NOTES.rst`: one-line `Maintenance` subsection entry inside
  the next-unreleased RST comment block, referencing `:issue:`112``.

## Verification
- `pre-commit run --all-files` — all hooks pass.
- `pytest -q` — 959 passed, 30 xfailed, 6 xpassed, **4 failed**.
  All 4 failures are pre-existing `XPASS(strict)` cases on `main`
  (`test_cross_validation.py::test_forward_inverse_roundtrip` and
  `test_two_theta_matches_reference` for `kappa4cv`/`kappa6c`
  `sapphire-012`), unrelated to this PR.  Confirmed identical
  failures on `main`; xfail markers need separate maintenance.
- Bump script sanity run — exits 0 (no-op; all year ranges already
  current).

## Cross-repo coordination
- Reference implementation: BCDA-APS/ad_hoc_diffractometer#291 (PR
  open, awaiting review).  Bump-script source text copied directly
  from that branch; no divergence.
- Final repo in the trilogy: bluesky/hklpy2#411.

## Independent of #62
This work touches only copyright/attribution metadata and is
independent of the `bluesky` org move (#62).  Merge order does not
matter.

Agent: OpenCode (claudeopus47)

