### PR TITLE
test #114 drop stale issue-#99 xfails fixed upstream in v0.11.1

### DIFF
--- a/.github/workflows/cross-validation.yml
+++ b/.github/workflows/cross-validation.yml
@@ -80,13 +80,12 @@ jobs:
           cache-environment: true
 
       - name: Install pip-only dependencies
-        # ``diffcalc-core`` is not on conda-forge.  ``ad_hoc_diffractometer``
-        # is pip-upgraded to outpace the conda-forge feedstock lag
-        # (:issue:`99`, :issue:`114`); drop the pin once the feedstock
-        # catches up to the ``pyproject.toml`` floor.
+        # ``diffcalc-core`` is the only runtime dep not on conda-forge.
+        # If a conda-forge feedstock later falls behind the
+        # ``pyproject.toml`` floor, add ``pip install --upgrade`` lines
+        # for the affected packages here.
         run: |
           pip install diffcalc-core
-          pip install --upgrade "ad_hoc_diffractometer>=0.11.1"
 
       - name: Install hklpy2_solvers (editable, no deps)
         # Use --no-deps because all runtime deps are already provided

--- a/.github/workflows/cross-validation.yml
+++ b/.github/workflows/cross-validation.yml
@@ -80,20 +80,13 @@ jobs:
           cache-environment: true
 
       - name: Install pip-only dependencies
-        # diffcalc-core is not packaged on conda-forge; install it
-        # from PyPI into the conda env.  ``ad_hoc_diffractometer`` is
-        # bumped to the PyPI release because the conda-forge feedstock
-        # tracks releases asynchronously (see :issue:`99`); remove the
-        # explicit pin once the feedstock catches up to the
-        # ``pyproject.toml`` floor.  ``hklpy2`` is bumped to the PyPI
-        # release for the same reason (see :issue:`108`); the
-        # conda-forge ``hkl`` package above keeps the libhkl GI
-        # bindings in place.  Remove the explicit ``hklpy2`` pip pin
-        # once the conda-forge feedstock ships >=0.7.1.
+        # ``diffcalc-core`` is not on conda-forge.  ``ad_hoc_diffractometer``
+        # is pip-upgraded to outpace the conda-forge feedstock lag
+        # (:issue:`99`, :issue:`114`); drop the pin once the feedstock
+        # catches up to the ``pyproject.toml`` floor.
         run: |
           pip install diffcalc-core
-          pip install --upgrade "ad_hoc_diffractometer>=0.11.0"
-          pip install --upgrade "hklpy2>=0.7.1"
+          pip install --upgrade "ad_hoc_diffractometer>=0.11.1"
 
       - name: Install hklpy2_solvers (editable, no deps)
         # Use --no-deps because all runtime deps are already provided

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -43,6 +43,7 @@ describe future plans.
     Documentation
     ~~~~~~~~~~~~~
 
+    * Document how to override fixed-axis default values in the ``ad_hoc`` guide.  :issue:`114`
     * Document how to set the reference vector (n̂) in the ``ad_hoc`` guide.  :issue:`114`
 
     Maintenance

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -29,6 +29,12 @@ describe future plans.
 
     Expected release: tba
 
+    New Features
+    ~~~~~~~~~~~~
+
+    * Add ``AdHocSolver.update_mode_constraints`` for fixed-axis defaults.  :issue:`114`
+    * Add ``DiffcalcSolver.update_mode_constraints`` for user-mode value overrides.  :issue:`114`
+
     Enhancements
     ~~~~~~~~~~~~
 

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -32,6 +32,7 @@ describe future plans.
     Maintenance
     ~~~~~~~~~~~
 
+    * Bump ``ad_hoc_diffractometer`` floor to ``>=0.11.1``.  :issue:`114`
     * Unify copyright automation across hklpy2 family.  :issue:`112`
 
 0.3.3

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -40,6 +40,11 @@ describe future plans.
 
     * Use ``ConstraintSet.with_constraint_values()`` in ``AdHocSolver.extras`` setter.  :issue:`114`
 
+    Documentation
+    ~~~~~~~~~~~~~
+
+    * Document how to set the reference vector (n̂) in the ``ad_hoc`` guide.  :issue:`114`
+
     Maintenance
     ~~~~~~~~~~~
 

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -29,6 +29,11 @@ describe future plans.
 
     Expected release: tba
 
+    Enhancements
+    ~~~~~~~~~~~~
+
+    * Use ``ConstraintSet.with_constraint_values()`` in ``AdHocSolver.extras`` setter.  :issue:`114`
+
     Maintenance
     ~~~~~~~~~~~
 

--- a/docs/source/geometries.rst
+++ b/docs/source/geometries.rst
@@ -28,6 +28,15 @@ library.  All geometries registered in the
 library's geometry registry (including via entry points) are
 automatically available.  The pseudo axes are always ``h``, ``k``, ``l``.
 
+In the per-mode tables below the ``extra(s)`` column names the
+:attr:`~ad_hoc_diffractometer.diffractometer.AdHocDiffractometer.surface_normal`
+or
+:attr:`~ad_hoc_diffractometer.diffractometer.AdHocDiffractometer.azimuthal_reference`
+attribute that the mode reads (set on the underlying geometry object),
+followed by any per-call scalar extras (``psi``, ``alpha_i``,
+``beta_out``).  See :ref:`guide_ad_hoc.reference_vector` for the
+recipes.
+
 .. _geometry.fourcv:
 
 fourcv
@@ -81,7 +90,7 @@ See `ad_hoc_diffractometer fourcv
    * - ``fixed_psi``
      - *(none)*
      - omega, chi, phi, ttheta
-     - n_hat, psi
+     - azimuthal_reference, psi
    * - ``double_diffraction``
      - *(none)*
      - omega, chi, phi, ttheta
@@ -140,7 +149,7 @@ See `ad_hoc_diffractometer fourch
    * - ``fixed_psi``
      - *(none)*
      - omega, chi, phi, ttheta
-     - n_hat, psi
+     - azimuthal_reference, psi
    * - ``double_diffraction``
      - *(none)*
      - omega, chi, phi, ttheta
@@ -195,23 +204,23 @@ See `ad_hoc_diffractometer psic
    * - ``fixed_alpha_i_vertical``
      - mu, nu
      - eta, chi, phi, delta
-     - n_hat, alpha_i, beta_out
+     - surface_normal, alpha_i, beta_out
    * - ``fixed_beta_out_vertical``
      - mu, nu
      - eta, chi, phi, delta
-     - n_hat, alpha_i, beta_out
+     - surface_normal, alpha_i, beta_out
    * - ``alpha_eq_beta_vertical``
      - mu, nu
      - eta, chi, phi, delta
-     - n_hat, alpha_i, beta_out
+     - surface_normal, alpha_i, beta_out
    * - ``fixed_psi_vertical``
      - mu, nu
      - eta, chi, phi, delta
-     - n_hat, psi
+     - azimuthal_reference, psi
    * - ``fixed_alpha_i_fixed_chi_fixed_phi``
      - chi, phi
      - mu, eta, nu, delta
-     - n_hat, alpha_i, beta_out
+     - surface_normal, alpha_i, beta_out
    * - ``fixed_omega_vertical``
      - mu, nu
      - eta, chi, phi, delta
@@ -235,19 +244,19 @@ See `ad_hoc_diffractometer psic
    * - ``fixed_alpha_i_horizontal``
      - delta, eta
      - mu, chi, phi, nu
-     - n_hat, alpha_i, beta_out
+     - surface_normal, alpha_i, beta_out
    * - ``fixed_beta_out_horizontal``
      - delta, eta
      - mu, chi, phi, nu
-     - n_hat, alpha_i, beta_out
+     - surface_normal, alpha_i, beta_out
    * - ``alpha_eq_beta_horizontal``
      - delta, eta
      - mu, chi, phi, nu
-     - n_hat, alpha_i, beta_out
+     - surface_normal, alpha_i, beta_out
    * - ``fixed_psi_horizontal``
      - delta, eta
      - mu, chi, phi, nu
-     - n_hat, psi
+     - azimuthal_reference, psi
    * - ``fixed_omega_horizontal``
      - delta, eta
      - mu, chi, phi, nu
@@ -325,15 +334,15 @@ See `ad_hoc_diffractometer sixc
    * - ``fixed_alpha_zaxis``
      - alpha, chi
      - omega, phi, delta, gamma
-     - n_hat, alpha_i, beta_out
+     - surface_normal, alpha_i, beta_out
    * - ``fixed_beta_zaxis``
      - chi, gamma
      - alpha, omega, phi, delta
-     - n_hat, alpha_i, beta_out
+     - surface_normal, alpha_i, beta_out
    * - ``alpha_eq_beta_zaxis``
      - chi, phi
      - alpha, omega, delta, gamma
-     - n_hat, alpha_i, beta_out
+     - surface_normal, alpha_i, beta_out
 
 .. _geometry.fivec:
 
@@ -445,7 +454,7 @@ See `ad_hoc_diffractometer kappa4cv
    * - ``fixed_psi``
      - *(none)*
      - komega, kappa, kphi, ttheta
-     - n_hat, psi
+     - azimuthal_reference, psi
    * - ``double_diffraction``
      - *(none)*
      - komega, kappa, kphi, ttheta
@@ -507,7 +516,7 @@ See `ad_hoc_diffractometer kappa4ch
    * - ``fixed_psi``
      - *(none)*
      - komega, kappa, kphi, ttheta
-     - n_hat, psi
+     - azimuthal_reference, psi
 
 .. _geometry.kappa6c:
 
@@ -578,11 +587,11 @@ See `ad_hoc_diffractometer kappa6c
    * - ``fixed_psi_vertical``
      - mu, omega (virtual)
      - komega, kappa, kphi, nu, delta
-     - n_hat, psi
+     - azimuthal_reference, psi
    * - ``fixed_psi_horizontal``
      - komega, mu
      - kappa, kphi, nu, delta
-     - n_hat, psi
+     - azimuthal_reference, psi
    * - ``double_diffraction_vertical``
      - mu, nu
      - komega, kappa, kphi, delta
@@ -637,11 +646,11 @@ See `ad_hoc_diffractometer zaxis
    * - ``zaxis``
      - *(none)*
      - alpha, Z, delta, gamma
-     - n_hat, alpha_i, beta_out
+     - surface_normal, alpha_i, beta_out
    * - ``reflectivity``
      - *(none)*
      - alpha, Z, delta, gamma
-     - n_hat, alpha_i, beta_out
+     - surface_normal, alpha_i, beta_out
 
 .. _geometry.s2d2:
 
@@ -684,7 +693,7 @@ See `ad_hoc_diffractometer s2d2
    * - ``reflectivity``
      - *(none)*
      - mu, Z, nu, delta
-     - n_hat, alpha_i, beta_out
+     - surface_normal, alpha_i, beta_out
 
 Kappa geometries
 ~~~~~~~~~~~~~~~~

--- a/docs/source/guide_ad_hoc.rst
+++ b/docs/source/guide_ad_hoc.rst
@@ -284,6 +284,79 @@ See the upstream
 <https://bcda-aps.github.io/ad_hoc_diffractometer/latest/howto/surface.html>`_
 how-to for the full mathematical background.
 
+.. _guide_ad_hoc.constraint_overrides:
+
+Override a fixed-axis default value
+------------------------------------
+
+Each ``fixed_<axis>`` mode (for example ``fourcv`` ``fixed_chi``,
+``psic`` ``fixed_chi_vertical``, ``fixed_alpha_i_fixed_chi_fixed_phi``)
+carries a default scalar value baked into the geometry's YAML
+definition.  Constraint values are immutable, so changing a default
+replaces the underlying
+:class:`~ad_hoc_diffractometer.mode.ConstraintSet` rather than mutating
+it in place.
+
+Use :meth:`~hklpy2_solvers.ad_hoc_solver.AdHocSolver.update_mode_constraints`
+to override one or more defaults without touching solver internals.
+
+Override a single sample-stage default:
+
+.. code-block:: python
+
+   psic2.core.solver.update_mode_constraints("fixed_chi_vertical", chi=45.0)
+   psic2.core.mode = "fixed_chi_vertical"
+
+Override several stages at once on a multi-fix mode:
+
+.. code-block:: python
+
+   psic2.core.solver.update_mode_constraints(
+       "fixed_alpha_i_fixed_chi_fixed_phi",
+       chi=15.0, phi=30.0, alpha_i=5.0,
+   )
+
+Operate on the currently active mode by omitting ``mode_name``:
+
+.. code-block:: python
+
+   psic2.core.solver.mode = "fixed_chi_vertical"
+   psic2.core.solver.update_mode_constraints(chi=10.0)
+
+(Assigning to ``psic2.core.solver.mode`` updates the adapter
+synchronously, which the active-mode shortcut requires.
+``psic2.core.mode = ...`` is cached by hklpy2's
+:class:`~hklpy2.ops.Core` and pushed to the solver on the next
+``update_solver()``, so it is not seen by
+``update_mode_constraints`` until a ``forward()`` runs.)
+
+Unknown mode names, unknown constraint names, and values rejected by
+the underlying library all raise :class:`~hklpy2.exceptions.SolverError`
+with a descriptive message.
+
+Persistent overrides vs. per-call reference scalars
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Two distinct routes touch reference-constraint scalars
+(``psi``, ``alpha_i``, ``beta_out``) on modes that expose them:
+
+* :meth:`~hklpy2_solvers.ad_hoc_solver.AdHocSolver.update_mode_constraints`
+  is the **persistent** route — the new value becomes the mode's
+  default for every subsequent ``forward()`` call until overridden
+  again.
+* The ``diff.core.extras = {"psi": ...}`` setter is the **per-call**
+  route — values come from hklpy2's Core and are pushed to the solver
+  on the next ``update_solver()``.
+
+For sample-stage constraints (``chi``, ``phi``, ``mu``, ``eta`` …)
+``update_mode_constraints`` is the only route; those names are not
+exposed through the ``extras`` interface.
+
+See the upstream
+`Work with Constraints and Diffraction Modes
+<https://bcda-aps.github.io/ad_hoc_diffractometer/latest/howto/constraints.html>`_
+how-to for the full constraint-system background.
+
 Available geometries at a glance
 ---------------------------------
 

--- a/docs/source/guide_ad_hoc.rst
+++ b/docs/source/guide_ad_hoc.rst
@@ -208,6 +208,82 @@ See the upstream
 `ad_hoc_diffractometer.reference <https://bcda-aps.github.io/ad_hoc_diffractometer/latest/api/reference.html>`_
 module for the mathematical definitions.
 
+.. _guide_ad_hoc.reference_vector:
+
+Set the reference vector (n̂)
+------------------------------
+
+Modes that involve a surface normal or an azimuthal reference (for
+example ``fixed_psi``, ``fixed_alpha_i_vertical``, ``zaxis``,
+``reflectivity``) require an external direction vector.  In every
+per-mode table that vector is shown as **n̂** (rendered as the
+``n_hat`` key in the mode's ``extras``), but **n̂ is a documentation
+placeholder, not a settable input**: the actual vector lives on the
+underlying geometry object, on one of two attributes selected by the
+mode's reference constraint.
+
+.. list-table:: Which geometry attribute does the active mode read?
+   :header-rows: 1
+   :widths: 35 30 35
+
+   * - Mode reference constraint
+     - Geometry attribute
+     - Set with
+   * - ``alpha_i``, ``beta_out``, ``a_eq_b``
+     - ``surface_normal``
+     - ``solver._geom.surface_normal = (h, k, l)``
+   * - ``psi``, ``naz``
+     - ``azimuthal_reference``
+     - ``solver._geom.azimuthal_reference = (h, k, l)``
+   * - ``omega`` (SPEC pseudo-angle)
+     - (none required)
+     - —
+
+To discover which attribute the active mode needs, ask the geometry
+directly:
+
+.. code-block:: python
+
+   psic2.core.mode = "fixed_alpha_i_vertical"
+   attr = psic2.core.solver._geom.required_reference_vector
+   # attr is 'surface_normal' for this mode; 'azimuthal_reference'
+   # for psi / naz modes; None when the active mode requires no
+   # reference vector.
+
+Two ways to set the vector
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Through the** ``extras`` **dict** — works only for ``n_hat`` and
+only for modes that consume ``surface_normal``:
+
+.. code-block:: python
+
+   psic2.core.extras = {"n_hat": (0, 0, 1)}
+
+**Directly on the geometry** — required for ``azimuthal_reference``;
+also works for ``surface_normal``:
+
+.. code-block:: python
+
+   psic2.core.solver._geom.surface_normal = (0, 0, 1)
+   psic2.core.solver._geom.azimuthal_reference = (1, 0, 0)
+
+The argument is a length-3 sequence of Miller indices.  ``(0, 0, 0)``
+is rejected with ``ValueError``; the default is ``None`` (not set).
+Clear an attribute by assigning ``None``.
+
+.. caution::
+
+   ``ad_hoc_diffractometer >= 0.11.1`` emits a ``UserWarning`` when
+   ``cs.extras["n_hat"]`` is overwritten directly with a real value
+   (the assignment has no effect on :meth:`forward`).  Use one of the
+   two recipes above instead; both bypass the placeholder.
+
+See the upstream
+`Surface Geometry and the Reference Vector
+<https://bcda-aps.github.io/ad_hoc_diffractometer/latest/howto/surface.html>`_
+how-to for the full mathematical background.
+
 Available geometries at a glance
 ---------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
   "Topic :: Scientific/Engineering",
 ]
 dependencies = [
-  "ad_hoc_diffractometer>=0.11.0",
+  "ad_hoc_diffractometer>=0.11.1",
   "diffcalc-core",
   "hklpy2>=0.7.1",
   "numpy",

--- a/src/hklpy2_solvers/ad_hoc_solver.py
+++ b/src/hklpy2_solvers/ad_hoc_solver.py
@@ -350,7 +350,11 @@ class AdHocSolver(SolverBase):
 
     @property
     def extras(self) -> dict[str, Any]:
-        """Current values of the mode's extra parameters."""
+        """Current values of the mode's extra parameters.
+
+        To discover which geometry attribute the active mode requires,
+        use ``solver._geom.required_reference_vector`` directly.
+        """
         out: dict[str, Any] = {}
         mode_obj = self._geom.mode
         if mode_obj is None:  # pragma: no cover - mode setter guarantees object
@@ -703,6 +707,9 @@ class AdHocSolver(SolverBase):
         :data:`_AD_HOC_BUILTIN_GEOMETRIES`, modes structurally
         identical to a fresh reference).  Otherwise returns a YAML-
         safe dict suitable for embedding in ``_metadata``.
+
+        The payload is the ``to_dict`` / ``from_dict`` dict shape; the
+        on-disk format is the public contract under :issue:`108`.
         """
         live = self._geom.to_dict()
         if self.geometry in _AD_HOC_BUILTIN_GEOMETRIES:

--- a/src/hklpy2_solvers/ad_hoc_solver.py
+++ b/src/hklpy2_solvers/ad_hoc_solver.py
@@ -23,7 +23,6 @@ import numpy as np
 from ad_hoc_diffractometer.mode import (
     OPTIONAL,
     REQUIRED,
-    ConstraintSet,
     ConstraintViolation,
     EwaldSphereViolation,
 )
@@ -92,7 +91,7 @@ manages independently and must not round-trip through the solver
 state (avoids double-restore of samples and wavelength)."""
 
 _REFERENCE_EXTRA_NAMES: frozenset[str] = frozenset({"psi", "alpha_i", "beta_out"})
-"""Reference-constraint scalar extras (set via ConstraintSet rebuild)."""
+"""Reference-constraint scalar extras (set via ``ConstraintSet.with_constraint_values``)."""
 
 _DOUBLE_DIFF_EXTRA_NAMES: tuple[str, ...] = ("h2", "k2", "l2")
 """Double-diffraction Miller indices stored directly in mode.extras."""
@@ -380,8 +379,10 @@ class AdHocSolver(SolverBase):
         * ``n_hat``  -> ``geometry.surface_normal`` (length-3 sequence or
           ``None``).
         * ``psi``, ``alpha_i``, ``beta_out`` -> rebuild the active
-          :class:`ConstraintSet` via ``to_dict``/``from_dict`` so the
-          :class:`ReferenceConstraint` carries the new scalar value.
+          :class:`ConstraintSet` via
+          :meth:`~ad_hoc_diffractometer.mode.ConstraintSet.with_constraint_values`
+          so the :class:`ReferenceConstraint` carries the new scalar
+          value.
         * ``h2``, ``k2``, ``l2`` -> written directly into the mode's
           ``extras`` dict (used by double-diffraction modes).
 
@@ -412,20 +413,14 @@ class AdHocSolver(SolverBase):
                     self._geom.surface_normal = None
 
         # Reference-constraint scalar (psi / alpha_i / beta_out).
+        # ``ConstraintSet.with_constraint_values`` (upstream
+        # ad_hoc_diffractometer >= 0.11.1, :issue:`114`) returns a fresh
+        # ConstraintSet with the named scalar replaced, preserving order,
+        # extras, and cut_points.  Replace the per-mode ConstraintSet and
+        # re-select so that ``self._geom.mode`` returns the new object.
         rc = getattr(mode_obj, "reference_constraint", None)
         if rc is not None and rc.name in _REFERENCE_EXTRA_NAMES and rc.name in values:
-            new_value = float(values[rc.name])
-            cs_dict = mode_obj.to_dict()
-            # The ReferenceConstraint is guaranteed to be present because
-            # ``rc`` came from ``mode_obj.reference_constraint``; the loop
-            # always finds it and ``break``s.
-            for c in cs_dict.get("constraints", []):  # pragma: no branch
-                if c.get("type") == "ReferenceConstraint" and c.get("name") == rc.name:
-                    c["value"] = new_value
-                    break
-            new_cs = ConstraintSet.from_dict(cs_dict)
-            # Replace the per-mode ConstraintSet and re-select so that
-            # ``self._geom.mode`` returns the new object.
+            new_cs = mode_obj.with_constraint_values(**{rc.name: float(values[rc.name])})
             self._geom._modes[self._mode] = new_cs
             self._geom.mode_name = self._mode
 

--- a/src/hklpy2_solvers/ad_hoc_solver.py
+++ b/src/hklpy2_solvers/ad_hoc_solver.py
@@ -430,6 +430,84 @@ class AdHocSolver(SolverBase):
                 # Refresh mode_obj because rebuild above may have replaced it.
                 self._geom.mode.extras[k] = float(values[k])
 
+    def update_mode_constraints(self, mode_name: str | None = None, **updates: float | bool) -> None:
+        """Override default values of one or more constraints on a mode.
+
+        Each ``fixed_<axis>`` mode (e.g. ``fourcv`` ``fixed_chi``, ``psic``
+        ``fixed_alpha_i_vertical``) carries a default scalar value baked
+        into the geometry's YAML definition.  Constraint values are
+        immutable; this method replaces the named mode's
+        :class:`~ad_hoc_diffractometer.mode.ConstraintSet` with a fresh
+        instance produced by
+        :meth:`~ad_hoc_diffractometer.mode.ConstraintSet.with_constraint_values`,
+        leaving constraint order, :attr:`computed`, :attr:`extras`, and
+        :attr:`cut_points` unchanged.
+
+        Parameters
+        ----------
+        mode_name : str, optional
+            Name of the mode to update.  ``None`` (default) operates on
+            the active mode (:attr:`mode`).
+        **updates : float or bool
+            Mapping of constraint name → new value, where each key matches
+            the ``.name`` attribute of an existing
+            :class:`~ad_hoc_diffractometer.mode.SampleConstraint`,
+            :class:`~ad_hoc_diffractometer.mode.DetectorConstraint`, or
+            :class:`~ad_hoc_diffractometer.mode.ReferenceConstraint` in
+            the mode.  Reference-constraint scalars (``psi``, ``alpha_i``,
+            ``beta_out``) can also be updated through the per-call
+            :attr:`extras` setter; this method is the route for persistent
+            overrides of fixed-axis defaults.
+
+        Raises
+        ------
+        SolverError
+            If ``mode_name`` is unknown, if any kwarg names a constraint
+            not present in the mode, or if a value cannot be converted to
+            the expected numeric type.
+
+        Examples
+        --------
+        Override a single sample-stage default::
+
+            solver.update_mode_constraints("fixed_chi", chi=45.0)
+
+        Override several stages at once on a multi-fix mode::
+
+            solver.update_mode_constraints(
+                "fixed_alpha_i_fixed_chi_fixed_phi",
+                chi=15.0, phi=30.0, alpha_i=5.0,
+            )
+
+        Operate on the currently active mode::
+
+            solver.mode = "fixed_chi"
+            solver.update_mode_constraints(chi=45.0)
+        """
+        target_mode = self._mode if mode_name is None else mode_name
+        try:
+            cs = self._geom.modes[target_mode]
+        except KeyError as exc:
+            available = sorted(self._geom.modes.keys())
+            raise SolverError(f"Unknown mode {target_mode!r}; available modes: {available}") from exc
+        try:
+            new_cs = cs.with_constraint_values(**updates)
+        except KeyError as exc:
+            # ``with_constraint_values`` raises KeyError for unknown
+            # constraint names; surface as SolverError with the upstream
+            # message preserved.
+            raise SolverError(f"update_mode_constraints({target_mode!r}, **{updates!r}): {exc.args[0]}") from exc
+        except (TypeError, ValueError) as exc:
+            # ``with_constraint_values`` calls ``float(value)`` on each
+            # update; bad types raise TypeError, bad strings raise
+            # ValueError.  Both indicate caller error.
+            raise SolverError(f"update_mode_constraints({target_mode!r}, **{updates!r}): {exc}") from exc
+        self._geom._modes[target_mode] = new_cs
+        # Re-select the mode if it is the active one so that
+        # ``self._geom.mode`` returns the new ConstraintSet object.
+        if target_mode == self._mode:
+            self._geom.mode_name = self._mode
+
     @property
     def _summary_dict(self) -> KeyValueMap:
         """Return a summary of the geometry (modes, axes).

--- a/src/hklpy2_solvers/diffcalc_solver.py
+++ b/src/hklpy2_solvers/diffcalc_solver.py
@@ -821,6 +821,124 @@ class DiffcalcSolver(SolverBase):
             self._mode = ""
             self._applied_mode = None
 
+    def update_mode_constraints(self, mode_name: str | None = None, **updates: float | bool) -> None:
+        """Override constraint values on a previously-registered user mode.
+
+        Sibling of :meth:`hklpy2_solvers.ad_hoc_solver.AdHocSolver.update_mode_constraints`
+        for the diffcalc backend.  Replaces one or more constraint values
+        in an existing user-registered mode without changing the mode's
+        constraint names or structure.  Built-in modes are frozen and
+        cannot be modified — register a variant under a new name with
+        :meth:`register_mode` instead.
+
+        Parameters
+        ----------
+        mode_name : str, optional
+            Name of the mode to update.  ``None`` (default) operates on
+            the active mode (:attr:`mode`).  Matched order-independently
+            against registered constraint-name sets, so any permutation
+            of the original name resolves to the same mode (see
+            :issue:`109`).
+        **updates : float or bool
+            Mapping of constraint name → new value.  Each key must
+            already exist as a constraint name in the resolved mode
+            (this method does not add or remove constraints — use
+            :meth:`unregister_mode` + :meth:`register_mode` for structural
+            changes).  Float values pin the named axis at that value;
+            ``True`` activates a boolean constraint (``a_eq_b``,
+            ``bin_eq_bout``, ``bisect``).
+
+        Raises
+        ------
+        SolverError
+            If ``mode_name`` is unknown; if it names a built-in mode
+            (built-ins are frozen); if any kwarg names a constraint not
+            present in the mode; or if the resulting constraint
+            combination is rejected by diffcalc (same-category
+            collision, not-implemented, etc.).
+
+        Notes
+        -----
+        Mutates the user-mode dict in place and clears
+        :attr:`_applied_mode` so that a subsequent :meth:`forward` /
+        :meth:`inverse` rebuilds the diffcalc
+        :class:`~diffcalc.hkl.constraints.Constraints` object with the
+        new values.  The mode's display name is unchanged.
+
+        Examples
+        --------
+        Register a custom mode then later override one value::
+
+            solver.register_mode(
+                "fixed_delta fixed_eta fixed_chi",
+                {"delta": 0.0, "eta": 0.0, "chi": 0.0},
+            )
+            solver.update_mode_constraints(
+                "fixed_delta fixed_eta fixed_chi", chi=45.0,
+            )
+
+        Operate on the currently active mode::
+
+            solver.mode = "fixed_delta fixed_eta fixed_chi"
+            solver.update_mode_constraints(chi=45.0)
+        """
+        target_input = self._mode if mode_name is None else mode_name
+        if not isinstance(target_input, str):
+            raise SolverError(f"Mode name must be a string, received {target_input!r}.")
+        token_key = frozenset(target_input.split())
+        if token_key in _MODES_BY_TOKENS:
+            existing = _MODES_BY_TOKENS[token_key]
+            raise SolverError(
+                f"Cannot modify built-in mode {existing!r}; register a variant under a new name instead."
+            )
+        if token_key not in self._user_modes_by_tokens:
+            raise SolverError(f"User mode {target_input!r} is not registered.")
+        canonical = self._user_modes_by_tokens[token_key]
+        existing_constraints = self._user_modes[canonical]
+        unknown = sorted(set(updates) - set(existing_constraints))
+        if unknown:
+            raise SolverError(
+                f"update_mode_constraints({canonical!r}): constraint(s) "
+                f"{unknown!r} not present in this mode; available: "
+                f"{sorted(existing_constraints)}."
+            )
+        # Build the prospective constraint dict and validate it through
+        # diffcalc the same way ``register_mode`` does, so any value-side
+        # error (bad type, same-category collision, not-implemented) is
+        # caught before mutation.
+        candidate = {**existing_constraints, **updates}
+        try:
+            probe = Constraints(candidate)
+        except (DiffcalcException, ValueError) as exc:
+            raise SolverError(f"diffcalc rejected updated constraints for {canonical!r}: {exc}") from exc
+        # Defensive: same-category collapse and not-implemented are
+        # structurally unreachable here because ``register_mode``
+        # already validated the constraint *name set* at registration
+        # time, and this method only mutates values (never adds or
+        # removes keys).  Kept for parity with ``register_mode`` and
+        # to guard against any future diffcalc value-dependent
+        # implementation gate.
+        if set(probe.asdict) != set(candidate):  # pragma: no cover - defensive
+            dropped = sorted(set(candidate) - set(probe.asdict))
+            raise SolverError(
+                f"update_mode_constraints({canonical!r}): constraints "
+                f"{dropped!r} were dropped by diffcalc (same-category "
+                f"conflict)."
+            )
+        try:
+            implemented = probe.is_current_mode_implemented()
+        except (DiffcalcException, ValueError) as exc:  # pragma: no cover - defensive
+            raise SolverError(f"diffcalc validation failed for {canonical!r}: {exc}") from exc
+        if not implemented:  # pragma: no cover - defensive
+            raise SolverError(
+                f"update_mode_constraints({canonical!r}): updated "
+                f"constraint combination is not implemented by diffcalc-core."
+            )
+        self._user_modes[canonical] = candidate
+        # Invalidate the applied-mode cache so the next forward()/inverse()
+        # rebuilds the diffcalc ``Constraints`` object with the new values.
+        self._applied_mode = None
+
     @property
     def wavelength(self) -> float | None:
         """Wavelength in Angstroms, for forward() and inverse()."""

--- a/tests/_hkl_library_probe.py
+++ b/tests/_hkl_library_probe.py
@@ -2,6 +2,14 @@
 Shim to test if "hkl" package (libhkl) can be imported.
 
 Importing this module succeeds only if libhkl is loadable via gi.
+
+Failure is re-raised as :class:`ModuleNotFoundError` (a subclass of
+:class:`ImportError`) so that :func:`pytest.importorskip` skips
+correctly under both legacy pytest (``exc_type=ImportError`` default
+through 9.0) and pytest >= 9.1, which defaults
+``exc_type=ModuleNotFoundError`` and no longer catches a plain
+:class:`ImportError` raised from a module body.  See pytest issue
+`#11523 <https://github.com/pytest-dev/pytest/issues/11523>`_.
 """
 
 try:
@@ -10,4 +18,4 @@ try:
     gi.require_version("Hkl", "5.0")
     from gi.repository import Hkl  # noqa: F401
 except Exception as exc:  # ValueError from require_version, etc.
-    raise ImportError(f"libhkl not available: {exc}") from exc
+    raise ModuleNotFoundError(f"libhkl not available: {exc}") from exc

--- a/tests/test_ad_hoc_solver.py
+++ b/tests/test_ad_hoc_solver.py
@@ -2317,3 +2317,144 @@ def test_metadata_user_registered_geometry(parms, context):
         from ad_hoc_diffractometer import factories as _factories
 
         _factories._GEOMETRY_REGISTRY.pop(custom_name, None)
+
+
+# ---------------------------------------------------------------------------
+# Override fixed-axis default values via ``update_mode_constraints`` (:issue:`114`)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(
+                geometry="fourcv",
+                active_mode="bisecting",
+                target_mode="fixed_chi",
+                updates={"chi": 45.0},
+                check_mode="fixed_chi",
+                check_constraint="chi",
+                check_value=45.0,
+            ),
+            does_not_raise(),
+            id="override fixed_chi default on named (inactive) mode",
+        ),
+        pytest.param(
+            dict(
+                geometry="fourcv",
+                active_mode="fixed_chi",
+                target_mode=None,  # active-mode shortcut
+                updates={"chi": 30.0},
+                check_mode="fixed_chi",
+                check_constraint="chi",
+                check_value=30.0,
+            ),
+            does_not_raise(),
+            id="override default on active mode via None shortcut",
+        ),
+        pytest.param(
+            dict(
+                geometry="psic",
+                active_mode="bisecting_vertical",
+                target_mode="fixed_phi_vertical",
+                updates={"phi": 10.0, "mu": 0.0},
+                check_mode="fixed_phi_vertical",
+                check_constraint="phi",
+                check_value=10.0,
+            ),
+            does_not_raise(),
+            id="multi-stage override on psic fixed_phi_vertical",
+        ),
+        pytest.param(
+            dict(
+                geometry="fourcv",
+                active_mode="bisecting",
+                target_mode="bogus_mode",
+                updates={"chi": 0.0},
+                check_mode=None,
+                check_constraint=None,
+                check_value=None,
+            ),
+            pytest.raises(SolverError, match=re.escape("Unknown mode 'bogus_mode'")),
+            id="unknown mode name raises SolverError",
+        ),
+        pytest.param(
+            dict(
+                geometry="fourcv",
+                active_mode="bisecting",
+                target_mode="fixed_chi",
+                updates={"bogus_axis": 1.0},
+                check_mode=None,
+                check_constraint=None,
+                check_value=None,
+            ),
+            pytest.raises(SolverError, match=re.escape("update_mode_constraints('fixed_chi'")),
+            id="unknown constraint name raises SolverError",
+        ),
+        pytest.param(
+            dict(
+                geometry="fourcv",
+                active_mode="bisecting",
+                target_mode="fixed_chi",
+                updates={"chi": "not_a_number"},
+                check_mode=None,
+                check_constraint=None,
+                check_value=None,
+            ),
+            pytest.raises(SolverError, match=re.escape("update_mode_constraints('fixed_chi'")),
+            id="bad value type raises SolverError",
+        ),
+    ],
+)
+def test_update_mode_constraints(parms, context):
+    """``update_mode_constraints`` overrides mode-baked default values.
+
+    Wraps :meth:`ad_hoc_diffractometer.mode.ConstraintSet.with_constraint_values`
+    (upstream :issue:`293`) so users have a sanctioned API for changing
+    a ``fixed_AXIS`` default without poking ``solver._geom._modes`` by
+    hand.  Upstream ``KeyError`` / ``TypeError`` / ``ValueError`` are
+    surfaced as :class:`~hklpy2.exceptions.SolverError`.
+    """
+    with context:
+        solver = AdHocSolver(parms["geometry"])
+        solver.mode = parms["active_mode"]
+        solver.update_mode_constraints(parms["target_mode"], **parms["updates"])
+        # Success-path assertions only run when no exception was raised.
+        cs = solver._geom.modes[parms["check_mode"]]
+        # Find the named constraint by its .name attribute.
+        matched = [c for c in cs._constraints if getattr(c, "name", None) == parms["check_constraint"]]
+        assert len(matched) == 1, f"expected exactly one constraint named {parms['check_constraint']!r}"
+        assert matched[0].value == parms["check_value"]
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(
+                geometry="fourcv",
+                active_mode="fixed_chi",
+                new_chi=45.0,
+            ),
+            does_not_raise(),
+            id="fourcv fixed_chi override is observed on next forward()",
+        ),
+    ],
+)
+def test_update_mode_constraints_is_observed_by_forward(parms, context):
+    """The new constraint value reaches the solver on the next ``forward()``.
+
+    Ensures the ``_geom._modes`` write + ``mode_name`` re-select pattern
+    actually replaces the active ConstraintSet for downstream calls.
+    """
+    with context:
+        solver = _make_solver_with_ub(geometry=parms["geometry"], mode=parms["active_mode"])
+        # Default chi for fourcv fixed_chi is 90.0; override.
+        solver.update_mode_constraints(chi=parms["new_chi"])
+        solutions = solver.forward({"h": 1.0, "k": 0.0, "l": 0.0})
+        assert len(solutions) > 0
+        for sol in solutions:
+            assert sol["chi"] == parms["new_chi"], (
+                f"chi expected {parms['new_chi']} got {sol['chi']} (mode override not applied)"
+            )

--- a/tests/test_ad_hoc_solver.py
+++ b/tests/test_ad_hoc_solver.py
@@ -4,6 +4,7 @@
 
 import math
 import re
+import warnings
 from contextlib import nullcontext as does_not_raise
 
 import pytest
@@ -2458,3 +2459,101 @@ def test_update_mode_constraints_is_observed_by_forward(parms, context):
             assert sol["chi"] == parms["new_chi"], (
                 f"chi expected {parms['new_chi']} got {sol['chi']} (mode override not applied)"
             )
+
+
+# ---------------------------------------------------------------------------
+# Adapter does not trip upstream n_hat placeholder warning (:issue:`114`)
+# ad_hoc_diffractometer >= 0.11.1 emits ``UserWarning`` when
+# ``cs.extras['n_hat']`` is overwritten (BCDA-APS#294).  The adapter
+# routes ``n_hat`` exclusively to ``geometry.surface_normal`` and never
+# writes the placeholder, so the warning must never fire from any
+# adapter-internal code path.
+# ---------------------------------------------------------------------------
+
+
+def _exercise_creator_extras_bootstrap(geometry: str) -> None:
+    """Build via ``hklpy2.creator`` (forces Core to push extras with ``n_hat``)."""
+    import hklpy2
+
+    sim = hklpy2.creator(solver="ad_hoc", geometry=geometry)
+    # Force ``update_solver()`` to run by reading core extras (which
+    # triggers the EXTRAS dirty push if any state is pending).
+    _ = sim.core.solver.extras
+
+
+def _exercise_direct_n_hat_write(geometry: str, mode: str) -> None:
+    """Write ``n_hat`` through the adapter's ``extras`` setter."""
+    solver = AdHocSolver(geometry)
+    solver.mode = mode
+    solver.extras = {"n_hat": (0.0, 0.0, 1.0)}
+
+
+def _exercise_psi_scalar_write(geometry: str, mode: str) -> None:
+    """Write a reference-constraint scalar (exercises C2 refactored path)."""
+    solver = AdHocSolver(geometry)
+    solver.mode = mode
+    solver.extras = {"psi": 30.0}
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(exercise=_exercise_creator_extras_bootstrap, args=("zaxis",)),
+            does_not_raise(),
+            id="creator bootstrap on zaxis (default mode exposes n_hat)",
+        ),
+        pytest.param(
+            dict(exercise=_exercise_creator_extras_bootstrap, args=("psic",)),
+            does_not_raise(),
+            id="creator bootstrap on psic",
+        ),
+        pytest.param(
+            dict(exercise=_exercise_direct_n_hat_write, args=("psic", "fixed_alpha_i_vertical")),
+            does_not_raise(),
+            id="adapter extras setter routes n_hat to surface_normal",
+        ),
+        pytest.param(
+            dict(exercise=_exercise_direct_n_hat_write, args=("fourcv", "fixed_psi")),
+            does_not_raise(),
+            id="adapter extras setter routes n_hat on fourcv fixed_psi",
+        ),
+        pytest.param(
+            dict(exercise=_exercise_psi_scalar_write, args=("fourcv", "fixed_psi")),
+            does_not_raise(),
+            id="extras setter psi scalar via with_constraint_values does not warn",
+        ),
+        pytest.param(
+            dict(exercise=_exercise_psi_scalar_write, args=("psic", "fixed_psi_vertical")),
+            does_not_raise(),
+            id="extras setter psi scalar on psic fixed_psi_vertical does not warn",
+        ),
+    ],
+)
+def test_adapter_does_not_emit_n_hat_placeholder_warning(parms, context):
+    """No adapter code path triggers the upstream n_hat placeholder warning.
+
+    ``ad_hoc_diffractometer >= 0.11.1`` (BCDA-APS#294) emits a
+    :class:`UserWarning` whenever ``ConstraintSet.extras['n_hat']`` is
+    overwritten with a real value, because the actual surface-normal
+    vector lives on the geometry attribute (``surface_normal`` or
+    ``azimuthal_reference``), not in the per-mode extras dict.
+
+    The adapter must never trip this warning from its own code: it
+    routes ``n_hat`` to ``geometry.surface_normal`` (see
+    :class:`~hklpy2_solvers.ad_hoc_solver.AdHocSolver.extras` setter)
+    and uses :meth:`ConstraintSet.with_constraint_values` (not direct
+    extras writes) for reference-constraint scalars.  This test
+    captures all warnings emitted during representative adapter
+    operations and asserts that none whose message names ``n_hat``
+    is a :class:`UserWarning`.
+    """
+    with context:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            parms["exercise"](*parms["args"])
+        offending = [w for w in caught if issubclass(w.category, UserWarning) and "n_hat" in str(w.message)]
+        assert not offending, (
+            f"adapter unexpectedly tripped upstream n_hat placeholder warning(s): "
+            f"{[(w.category.__name__, str(w.message)) for w in offending]}"
+        )

--- a/tests/test_cross_validation.py
+++ b/tests/test_cross_validation.py
@@ -458,7 +458,8 @@ KNOWN_TTH_DISAGREEMENTS = {
 # and :issue:`77` (``ad_hoc/kappa6c bisecting_horizontal`` multi-sample
 # reflection set) was resolved upstream by ``ad_hoc_diffractometer >=
 # 0.11.0`` (PR #281 / issue #280: rotation-composition order, basis-
-# aware ``ub_identity``, BL1967 B-matrix orthogonalized frame); those
+# aware ``ub_identity``, BL1967 B-matrix orthogonalized frame), and the
+# fix remains in the current ``>=0.11.1`` floor (:issue:`114`); those
 # cases are now covered by ``does_not_raise()`` parametrizations in the
 # dedicated regression tests below.
 KNOWN_FORWARD_GAPS = {
@@ -474,10 +475,12 @@ KNOWN_FORWARD_GAPS = {
     # three ``ad_hoc`` horizontal-bisecting modes (``fourch bisecting``,
     # ``psic bisecting_vertical``, ``kappa6c bisecting_horizontal``)
     # decline the trigonal-rhombohedral reflection ``(1, 1, 0)`` on
-    # both ``ad_hoc_diffractometer 0.10.1`` and ``0.11.0``.  The
-    # ``hkl_soleil`` peers (``E4CH``, ``K6C``) solve the same
-    # reflection with ``|chi| ~ 51 deg`` / ``|kappa| ~ 97 deg``
-    # branches that the bisecting solvers do not enumerate.
+    # ``ad_hoc_diffractometer 0.10.1``, ``0.11.0``, and the current
+    # ``>=0.11.1`` floor (upstream #285 added a regression test in
+    # 0.11.1 confirming the gap is unfixed).  The ``hkl_soleil`` peers
+    # (``E4CH``, ``K6C``) solve the same reflection with
+    # ``|chi| ~ 51 deg`` / ``|kappa| ~ 97 deg`` branches that the
+    # bisecting solvers do not enumerate.
     ("euler_horizontal", "fourch", "trigonal_rhombohedral", (1, 1, 0)): "issue #69",
     ("euler_horizontal", "psic", "trigonal_rhombohedral", (1, 1, 0)): "issue #69",
     ("kappa_horizontal", "kappa6c", "trigonal_rhombohedral", (1, 1, 0)): "issue #69",
@@ -505,11 +508,12 @@ CI_ENV_DEPENDENT_GAPS = {
     ("kappa_horizontal", "k6c", "triclinic", (1, 1, 0)): "issue #83",
     ("kappa_horizontal", "kappa4ch", "triclinic", (1, 1, 0)): "issue #83",
     # https://github.com/prjemian/hklpy2_solvers/issues/99 — ``kappa6c
-    # bisecting_horizontal`` triclinic (1, 1, 0) now solves locally
-    # under ``ad_hoc_diffractometer >= 0.11.0`` but the conda-forge CI
-    # env hits the same K6C bootstrap fragility as the existing
-    # :issue:`83` entries; non-strict so the case xfails on CI and
-    # passes silently on local runs.
+    # bisecting_horizontal`` triclinic (1, 1, 0) solves locally under
+    # the current ``ad_hoc_diffractometer >= 0.11.1`` floor (fix landed
+    # in 0.11.0), but the conda-forge CI env hits the same K6C
+    # bootstrap fragility as the existing :issue:`83` entries;
+    # non-strict so the case xfails on CI and passes silently on local
+    # runs.
     ("kappa_horizontal", "kappa6c", "triclinic", (1, 1, 0)): "issue #99",
 }
 

--- a/tests/test_cross_validation.py
+++ b/tests/test_cross_validation.py
@@ -462,16 +462,13 @@ KNOWN_TTH_DISAGREEMENTS = {
 # cases are now covered by ``does_not_raise()`` parametrizations in the
 # dedicated regression tests below.
 KNOWN_FORWARD_GAPS = {
-    # https://github.com/prjemian/hklpy2_solvers/issues/99 — tracked
-    # while an upstream issue is opened.  ``ad_hoc`` kappa-vertical
-    # bisecting modes (``kappa4cv bisecting``, ``kappa6c
-    # bisecting_vertical``) decline the sapphire asymmetric reflection
-    # ``(0, 1, 2)`` under ``ad_hoc_diffractometer >= 0.11.0``; the
-    # same parameter cases pass under ``0.10.1``.  The other
-    # kappa-vertical peer (``hkl_soleil/K4CV bissector``) and every
-    # other reflection in the sapphire scan still solve.
-    ("kappa_vertical", "kappa4cv", "sapphire", (0, 1, 2)): "issue #99",
-    ("kappa_vertical", "kappa6c", "sapphire", (0, 1, 2)): "issue #99",
+    # The kappa-vertical sapphire ``(0, 1, 2)`` gap previously tracked
+    # under :issue:`99` (``kappa4cv bisecting``, ``kappa6c
+    # bisecting_vertical``) was fixed upstream in
+    # ``ad_hoc_diffractometer >= 0.11.1`` by BCDA-APS PR #286 (issue
+    # #284: kappa equivalent-Eulerian chi axis now matches
+    # fourcv/fourch/psic).  Those two cases now solve and are covered
+    # by the default ``does_not_raise()`` parametrizations.
     # https://github.com/prjemian/hklpy2_solvers/issues/69 and upstream
     # https://github.com/BCDA-APS/ad_hoc_diffractometer/issues/285 -
     # three ``ad_hoc`` horizontal-bisecting modes (``fourch bisecting``,

--- a/tests/test_diffcalc_solver.py
+++ b/tests/test_diffcalc_solver.py
@@ -2065,6 +2065,166 @@ def test_modes_list_unchanged_by_permutations(parms, context):
 
 
 # ---------------------------------------------------------------------------
+# Override constraint values on a registered user mode (:issue:`114`)
+# update_mode_constraints sibling of AdHocSolver.update_mode_constraints.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(
+                preregister=True,
+                preselect=False,
+                target_mode=RUNTIME_MODE_NAME,
+                updates={"chi": 45.0},
+                expected_value=("chi", 45.0),
+            ),
+            does_not_raise(),
+            id="override single value on named user mode",
+        ),
+        pytest.param(
+            dict(
+                preregister=True,
+                preselect=True,
+                target_mode=None,  # active-mode shortcut
+                updates={"chi": 30.0},
+                expected_value=("chi", 30.0),
+            ),
+            does_not_raise(),
+            id="override default on active mode via None shortcut",
+        ),
+        pytest.param(
+            dict(
+                preregister=True,
+                preselect=False,
+                target_mode="fixed_chi fixed_delta fixed_eta",  # permutation of RUNTIME_MODE_NAME
+                updates={"eta": 12.0, "chi": 7.0},
+                expected_value=("eta", 12.0),
+            ),
+            does_not_raise(),
+            id="multi-value override resolves permuted name",
+        ),
+        pytest.param(
+            dict(
+                preregister=True,
+                preselect=False,
+                target_mode="bisect fixed_mu fixed_nu",  # built-in
+                updates={"mu": 5.0},
+                expected_value=None,
+            ),
+            pytest.raises(SolverError, match=re.escape("Cannot modify built-in mode")),
+            id="reject modification of built-in mode",
+        ),
+        pytest.param(
+            dict(
+                preregister=False,
+                preselect=False,
+                target_mode="never_registered",
+                updates={"mu": 0.0},
+                expected_value=None,
+            ),
+            pytest.raises(SolverError, match=re.escape("is not registered")),
+            id="reject unknown user mode name",
+        ),
+        pytest.param(
+            dict(
+                preregister=True,
+                preselect=False,
+                target_mode=RUNTIME_MODE_NAME,
+                updates={"bogus_axis": 1.0},
+                expected_value=None,
+            ),
+            pytest.raises(SolverError, match=re.escape("not present in this mode")),
+            id="reject constraint name not present in this mode",
+        ),
+        pytest.param(
+            dict(
+                preregister=True,
+                preselect=False,
+                target_mode=RUNTIME_MODE_NAME,
+                # Replace the chi sample constraint with mu would introduce a
+                # second sample-axis pin in a category diffcalc collapses.
+                # Use a non-string value to drive diffcalc rejection instead.
+                updates={"chi": "not_a_number"},
+                expected_value=None,
+            ),
+            pytest.raises(SolverError, match=re.escape("diffcalc rejected updated constraints")),
+            id="reject value rejected by diffcalc",
+        ),
+        pytest.param(
+            dict(
+                preregister=False,
+                preselect=False,
+                target_mode=123,  # non-string
+                updates={"chi": 0.0},
+                expected_value=None,
+            ),
+            pytest.raises(SolverError, match=re.escape("Mode name must be a string")),
+            id="reject non-string mode name",
+        ),
+    ],
+)
+def test_update_mode_constraints(parms, context):
+    """``update_mode_constraints`` overrides user-mode constraint values.
+
+    Sibling of
+    :func:`hklpy2_solvers.ad_hoc_solver.AdHocSolver.update_mode_constraints`
+    for the diffcalc backend.  Built-in modes are frozen (mirroring
+    :meth:`unregister_mode`); user modes mutate in place and the
+    ``_applied_mode`` cache is invalidated so subsequent forward/inverse
+    calls use the new values.  Permuted mode names resolve to the
+    registered display name (issue #109 token-set rule).
+    """
+    solver = DiffcalcSolver()
+    if parms["preregister"]:
+        solver.register_mode(RUNTIME_MODE_NAME, dict(RUNTIME_MODE_CONSTRAINTS))
+    if parms["preselect"]:
+        solver.mode = RUNTIME_MODE_NAME
+    with context:
+        solver.update_mode_constraints(parms["target_mode"], **parms["updates"])
+        # Success path only: verify the value landed and the cache was
+        # invalidated.
+        name = solver._resolve_mode_name(parms["target_mode"]) if parms["target_mode"] is not None else solver.mode
+        stored = solver._user_modes[name]
+        axis, expected = parms["expected_value"]
+        assert stored[axis] == expected, f"{axis!r} expected {expected!r} got {stored[axis]!r}"
+        assert solver._applied_mode is None, "applied-mode cache not invalidated"
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(new_chi=45.0),
+            does_not_raise(),
+            id="update is observed by next inverse() via rebuilt Constraints",
+        ),
+    ],
+)
+def test_update_mode_constraints_is_observed_by_inverse(parms, context):
+    """The new constraint value reaches diffcalc on the next ``inverse()``.
+
+    Ensures ``_applied_mode = None`` actually triggers a
+    :class:`~diffcalc.hkl.constraints.Constraints` rebuild and that the
+    updated value lands in the live diffcalc state.
+    """
+    solver = DiffcalcSolver()
+    solver.register_mode(RUNTIME_MODE_NAME, dict(RUNTIME_MODE_CONSTRAINTS))
+    solver.mode = RUNTIME_MODE_NAME
+    with context:
+        solver.update_mode_constraints(chi=parms["new_chi"])
+        # ``_apply_mode_constraints`` runs lazily through inverse() /
+        # forward(); calling it directly is the smallest assertion.
+        solver._apply_mode_constraints()
+        live = solver._constraints.asdict
+        assert live["chi"] == parms["new_chi"], (
+            f"diffcalc.Constraints['chi'] expected {parms['new_chi']} got {live.get('chi')}"
+        )
+
+
+# ---------------------------------------------------------------------------
 # Persist solver-defined state through export/restore (:issue:`108`)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
- #114
- partially addresses #99 (xfails removed; tracker issue can stay open until #114 work completes)

## Context

Issue #114 asks whether ``ad_hoc_diffractometer 0.11.1`` requires
any adjustments here.  Local pytest against an installed ``0.11.1``
dev build produced four ``XPASS(strict)`` failures in
``tests/test_cross_validation.py``:

- ``test_forward_inverse_roundtrip[kappa_vertical-kappa4cv-sapphire-012]``
- ``test_forward_inverse_roundtrip[kappa_vertical-kappa6c-sapphire-012]``
- ``test_two_theta_matches_reference[kappa_vertical-kappa4cv-sapphire-012]``
- ``test_two_theta_matches_reference[kappa_vertical-kappa6c-sapphire-012]``

These cases were marked ``xfail(strict=True)`` against issue #99,
which documented a kappa-vertical bisecting gap on sapphire
``(0, 1, 2)`` introduced by ``ad_hoc_diffractometer 0.11.0``.  The
underlying root cause (kappa equivalent-Eulerian ``chi`` axis
misalignment) was fixed upstream in ``ad_hoc_diffractometer 0.11.1``
via BCDA-APS PR #286 (issue #284), so both reflections now solve
correctly and the strict-xfail markers must go.

## Scope

This PR is intentionally narrow: it is the QC fix needed to land a
green baseline on ``main`` before the substantive #114 adoption work
(floor bump, workflow pin, refactor of the ``extras`` setter to use
``ConstraintSet.with_constraint_values()``, possible adoption of
``register_geometry_yaml``, release note) lands as subsequent
commits on this same branch.

## Change

- ``tests/test_cross_validation.py:464-476``: remove the two
  ``KNOWN_FORWARD_GAPS`` entries
  ``("kappa_vertical", "kappa4cv", "sapphire", (0, 1, 2))`` and
  ``("kappa_vertical", "kappa6c", "sapphire", (0, 1, 2))``; rewrite
  the surrounding comment to document that #284 fixed the gap
  upstream in 0.11.1.

## Verification

- ``pre-commit run --all-files``: 16 hooks, all pass.
- ``pytest ./tests``: 963 passed, 30 xfailed, 6 xpassed, 1 warning
  (the remaining 6 ``XPASS`` are pre-existing non-strict
  ``CI_ENV_DEPENDENT_GAPS`` entries unrelated to this fix).

Agent: OpenCode (claudeopus47)