### PR TITLE
Adopt ad_hoc_diffractometer v0.11.2 naming (incidence/emergence/azimuth)

### DIFF
--- a/.github/workflows/cross-validation.yml
+++ b/.github/workflows/cross-validation.yml
@@ -84,8 +84,13 @@ jobs:
         # If a conda-forge feedstock later falls behind the
         # ``pyproject.toml`` floor, add ``pip install --upgrade`` lines
         # for the affected packages here.
+        #
+        # ``ad-hoc-diffractometer`` is upgraded from PyPI because the
+        # conda-forge feedstock trails the ``pyproject.toml`` floor
+        # (>=0.11.2); remove once conda-forge catches up (:issue:`117`).
         run: |
           pip install diffcalc-core
+          pip install --upgrade "ad_hoc_diffractometer>=0.11.2"
 
       - name: Install hklpy2_solvers (editable, no deps)
         # Use --no-deps because all runtime deps are already provided

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -29,6 +29,13 @@ describe future plans.
 
     Expected release: tba
 
+    Breaking Changes
+    ~~~~~~~~~~~~~~~~
+
+    * Rename ``AdHocSolver.exit_angle`` to ``emergence_angle``.  :issue:`117`
+    * Rename ad_hoc ``alpha_i``/``beta_out`` extras to ``incidence``/``emergence``.  :issue:`117`
+    * Rename ad_hoc surface modes to ``fixed_incidence_*``/``fixed_emergence_*``/``specular_*``.  :issue:`117`
+
     New Features
     ~~~~~~~~~~~~
 
@@ -45,11 +52,13 @@ describe future plans.
 
     * Document how to override fixed-axis default values in the ``ad_hoc`` guide.  :issue:`114`
     * Document how to set the reference vector (n̂) in the ``ad_hoc`` guide.  :issue:`114`
+    * Refresh ``ad_hoc`` guide and geometry tables for ad_hoc v0.11.2 naming.  :issue:`117`
 
     Maintenance
     ~~~~~~~~~~~
 
     * Bump ``ad_hoc_diffractometer`` floor to ``>=0.11.1``.  :issue:`114`
+    * Bump ``ad_hoc_diffractometer`` floor to ``>=0.11.2``.  :issue:`117`
     * Unify copyright automation across hklpy2 family.  :issue:`112`
 
 0.3.3

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -59,6 +59,7 @@ describe future plans.
 
     * Bump ``ad_hoc_diffractometer`` floor to ``>=0.11.1``.  :issue:`114`
     * Bump ``ad_hoc_diffractometer`` floor to ``>=0.11.2``.  :issue:`117`
+    * Upgrade ``ad_hoc_diffractometer`` from PyPI in cross-validation CI.  :issue:`117`
     * Unify copyright automation across hklpy2 family.  :issue:`112`
 
 0.3.3

--- a/docs/source/geometries.rst
+++ b/docs/source/geometries.rst
@@ -31,10 +31,10 @@ automatically available.  The pseudo axes are always ``h``, ``k``, ``l``.
 In the per-mode tables below the ``extra(s)`` column names the
 :attr:`~ad_hoc_diffractometer.diffractometer.AdHocDiffractometer.surface_normal`
 or
-:attr:`~ad_hoc_diffractometer.diffractometer.AdHocDiffractometer.azimuthal_reference`
+:attr:`~ad_hoc_diffractometer.diffractometer.AdHocDiffractometer.azimuth`
 attribute that the mode reads (set on the underlying geometry object),
-followed by any per-call scalar extras (``psi``, ``alpha_i``,
-``beta_out``).  See :ref:`guide_ad_hoc.reference_vector` for the
+followed by any per-call scalar extras (``psi``, ``incidence``,
+``emergence``).  See :ref:`guide_ad_hoc.reference_vector` for the
 recipes.
 
 .. _geometry.fourcv:
@@ -90,7 +90,7 @@ See `ad_hoc_diffractometer fourcv
    * - ``fixed_psi``
      - *(none)*
      - omega, chi, phi, ttheta
-     - azimuthal_reference, psi
+     - azimuth, psi
    * - ``double_diffraction``
      - *(none)*
      - omega, chi, phi, ttheta
@@ -149,7 +149,7 @@ See `ad_hoc_diffractometer fourch
    * - ``fixed_psi``
      - *(none)*
      - omega, chi, phi, ttheta
-     - azimuthal_reference, psi
+     - azimuth, psi
    * - ``double_diffraction``
      - *(none)*
      - omega, chi, phi, ttheta
@@ -201,26 +201,26 @@ See `ad_hoc_diffractometer psic
      - chi, mu, nu
      - eta, phi, delta
      -
-   * - ``fixed_alpha_i_vertical``
-     - mu, nu
-     - eta, chi, phi, delta
-     - surface_normal, alpha_i, beta_out
-   * - ``fixed_beta_out_vertical``
-     - mu, nu
-     - eta, chi, phi, delta
-     - surface_normal, alpha_i, beta_out
-   * - ``alpha_eq_beta_vertical``
-     - mu, nu
-     - eta, chi, phi, delta
-     - surface_normal, alpha_i, beta_out
+   * - ``fixed_incidence_vertical``
+      - mu, nu
+      - eta, chi, phi, delta
+      - surface_normal, incidence, emergence
+   * - ``fixed_emergence_vertical``
+      - mu, nu
+      - eta, chi, phi, delta
+      - surface_normal, incidence, emergence
+   * - ``specular_vertical``
+      - mu, nu
+      - eta, chi, phi, delta
+      - surface_normal, incidence, emergence
    * - ``fixed_psi_vertical``
      - mu, nu
      - eta, chi, phi, delta
-     - azimuthal_reference, psi
-   * - ``fixed_alpha_i_fixed_chi_fixed_phi``
-     - chi, phi
-     - mu, eta, nu, delta
-     - surface_normal, alpha_i, beta_out
+     - azimuth, psi
+   * - ``fixed_incidence_fixed_chi_fixed_phi``
+      - chi, phi
+      - mu, eta, nu, delta
+      - surface_normal, incidence, emergence
    * - ``fixed_omega_vertical``
      - mu, nu
      - eta, chi, phi, delta
@@ -241,22 +241,22 @@ See `ad_hoc_diffractometer psic
      - chi, delta, eta
      - mu, phi, nu
      -
-   * - ``fixed_alpha_i_horizontal``
-     - delta, eta
-     - mu, chi, phi, nu
-     - surface_normal, alpha_i, beta_out
-   * - ``fixed_beta_out_horizontal``
-     - delta, eta
-     - mu, chi, phi, nu
-     - surface_normal, alpha_i, beta_out
-   * - ``alpha_eq_beta_horizontal``
-     - delta, eta
-     - mu, chi, phi, nu
-     - surface_normal, alpha_i, beta_out
+   * - ``fixed_incidence_horizontal``
+      - delta, eta
+      - mu, chi, phi, nu
+      - surface_normal, incidence, emergence
+   * - ``fixed_emergence_horizontal``
+      - delta, eta
+      - mu, chi, phi, nu
+      - surface_normal, incidence, emergence
+   * - ``specular_horizontal``
+      - delta, eta
+      - mu, chi, phi, nu
+      - surface_normal, incidence, emergence
    * - ``fixed_psi_horizontal``
      - delta, eta
      - mu, chi, phi, nu
-     - azimuthal_reference, psi
+     - azimuth, psi
    * - ``fixed_omega_horizontal``
      - delta, eta
      - mu, chi, phi, nu
@@ -331,18 +331,18 @@ See `ad_hoc_diffractometer sixc
      - alpha, gamma, omega
      - chi, phi, delta
      -
-   * - ``fixed_alpha_zaxis``
-     - alpha, chi
-     - omega, phi, delta, gamma
-     - surface_normal, alpha_i, beta_out
-   * - ``fixed_beta_zaxis``
-     - chi, gamma
-     - alpha, omega, phi, delta
-     - surface_normal, alpha_i, beta_out
-   * - ``alpha_eq_beta_zaxis``
-     - chi, phi
-     - alpha, omega, delta, gamma
-     - surface_normal, alpha_i, beta_out
+   * - ``fixed_incidence_zaxis``
+      - alpha, chi
+      - omega, phi, delta, gamma
+      - surface_normal, incidence, emergence
+   * - ``fixed_emergence_zaxis``
+      - chi, gamma
+      - alpha, omega, phi, delta
+      - surface_normal, incidence, emergence
+   * - ``specular_zaxis``
+      - chi, phi
+      - alpha, omega, delta, gamma
+      - surface_normal, incidence, emergence
 
 .. _geometry.fivec:
 
@@ -454,7 +454,7 @@ See `ad_hoc_diffractometer kappa4cv
    * - ``fixed_psi``
      - *(none)*
      - komega, kappa, kphi, ttheta
-     - azimuthal_reference, psi
+     - azimuth, psi
    * - ``double_diffraction``
      - *(none)*
      - komega, kappa, kphi, ttheta
@@ -516,7 +516,7 @@ See `ad_hoc_diffractometer kappa4ch
    * - ``fixed_psi``
      - *(none)*
      - komega, kappa, kphi, ttheta
-     - azimuthal_reference, psi
+     - azimuth, psi
 
 .. _geometry.kappa6c:
 
@@ -587,11 +587,11 @@ See `ad_hoc_diffractometer kappa6c
    * - ``fixed_psi_vertical``
      - mu, omega (virtual)
      - komega, kappa, kphi, nu, delta
-     - azimuthal_reference, psi
+     - azimuth, psi
    * - ``fixed_psi_horizontal``
      - komega, mu
      - kappa, kphi, nu, delta
-     - azimuthal_reference, psi
+     - azimuth, psi
    * - ``double_diffraction_vertical``
      - mu, nu
      - komega, kappa, kphi, delta
@@ -646,11 +646,11 @@ See `ad_hoc_diffractometer zaxis
    * - ``zaxis``
      - *(none)*
      - alpha, Z, delta, gamma
-     - surface_normal, alpha_i, beta_out
+     - surface_normal, incidence, emergence
    * - ``reflectivity``
      - *(none)*
      - alpha, Z, delta, gamma
-     - surface_normal, alpha_i, beta_out
+     - surface_normal, incidence, emergence
 
 .. _geometry.s2d2:
 
@@ -693,7 +693,7 @@ See `ad_hoc_diffractometer s2d2
    * - ``reflectivity``
      - *(none)*
      - mu, Z, nu, delta
-     - surface_normal, alpha_i, beta_out
+     - surface_normal, incidence, emergence
 
 Kappa geometries
 ~~~~~~~~~~~~~~~~

--- a/docs/source/guide_ad_hoc.rst
+++ b/docs/source/guide_ad_hoc.rst
@@ -143,8 +143,8 @@ motor positions.  ``fourc.real_position`` is the current readout of
 all real axes; pass a different set of values to compute ``(h, k, l)``
 at a hypothetical position instead.
 
-Derived quantities (ψ, α_i, β_out, n_az, OMEGA)
-------------------------------------------------
+Derived quantities (ψ, incidence, emergence, n_az, OMEGA)
+---------------------------------------------------------
 
 ``AdHocSolver`` exposes the six derived-quantity helpers from
 ``ad_hoc_diffractometer.reference`` as methods, so users do not need
@@ -159,12 +159,12 @@ to reach into ``solver._geom``:
      - Geometry prerequisite
    * - ``psi_angle(angles=None)``
      - Azimuthal angle ψ (deg) from motors
-     - ``azimuthal_reference`` set
+     - ``azimuth`` set
    * - ``incidence_angle(angles=None)``
-     - Incidence angle α_i (deg)
+     - Incidence angle (deg)
      - ``surface_normal`` set
-   * - ``exit_angle(angles=None)``
-     - Exit angle β_out (deg)
+   * - ``emergence_angle(angles=None)``
+     - Emergence angle (deg)
      - ``surface_normal`` set
    * - ``naz_angle(angles=None)``
      - Lab-frame azimuthal angle of n̂ (deg)
@@ -174,14 +174,14 @@ to reach into ``solver._geom``:
      - none
    * - ``natural_psi(h, k, l)``
      - Natural ψ (deg) from UB; ``None`` if undefined
-     - ``azimuthal_reference`` set
+     - ``azimuth`` set
 
 ``angles`` may be a dict keyed by real-axis name (any subset); ``None``
 (default) uses the geometry's current angles.  Unknown axis names raise
 :class:`~hklpy2.exceptions.SolverError`; a non-dict input raises
 ``TypeError``.
 
-The reference vectors ``azimuthal_reference`` and ``surface_normal``
+The reference vectors ``azimuth`` and ``surface_normal``
 are still configured on the underlying geometry object:
 
 .. code-block:: python
@@ -190,7 +190,7 @@ are still configured on the underlying geometry object:
 
    psic2 = hklpy2.creator(name="psic2", geometry="psic", solver="ad_hoc")
    solver = psic2.core.solver
-   solver._geom.azimuthal_reference = (0, 0, 1)
+   solver._geom.azimuth = (0, 0, 1)
    solver._geom.surface_normal = (1, 1, 6)
    solver._geom.wavelength = 1.0
 
@@ -198,8 +198,8 @@ are still configured on the underlying geometry object:
    solver.set_reals(angles)
 
    psi = solver.psi_angle(angles)
-   alpha_i = solver.incidence_angle(angles)
-   beta_out = solver.exit_angle(angles)
+   incidence = solver.incidence_angle(angles)
+   emergence = solver.emergence_angle(angles)
    naz = solver.naz_angle(angles)
    omega = solver.omega_pseudo(angles)
    natural = solver.natural_psi(1, 1, 1)
@@ -214,7 +214,7 @@ Set the reference vector (n̂)
 ------------------------------
 
 Modes that involve a surface normal or an azimuthal reference (for
-example ``fixed_psi``, ``fixed_alpha_i_vertical``, ``zaxis``,
+example ``fixed_psi``, ``fixed_incidence_vertical``, ``zaxis``,
 ``reflectivity``) require an external direction vector.  In every
 per-mode table that vector is shown as **n̂** (rendered as the
 ``n_hat`` key in the mode's ``extras``), but **n̂ is a documentation
@@ -229,12 +229,12 @@ mode's reference constraint.
    * - Mode reference constraint
      - Geometry attribute
      - Set with
-   * - ``alpha_i``, ``beta_out``, ``a_eq_b``
+   * - ``incidence``, ``emergence``, ``specular``
      - ``surface_normal``
      - ``solver._geom.surface_normal = (h, k, l)``
    * - ``psi``, ``naz``
-     - ``azimuthal_reference``
-     - ``solver._geom.azimuthal_reference = (h, k, l)``
+     - ``azimuth``
+     - ``solver._geom.azimuth = (h, k, l)``
    * - ``omega`` (SPEC pseudo-angle)
      - (none required)
      - —
@@ -244,9 +244,9 @@ directly:
 
 .. code-block:: python
 
-   psic2.core.mode = "fixed_alpha_i_vertical"
+   psic2.core.mode = "fixed_incidence_vertical"
    attr = psic2.core.solver._geom.required_reference_vector
-   # attr is 'surface_normal' for this mode; 'azimuthal_reference'
+   # attr is 'surface_normal' for this mode; 'azimuth'
    # for psi / naz modes; None when the active mode requires no
    # reference vector.
 
@@ -260,13 +260,13 @@ only for modes that consume ``surface_normal``:
 
    psic2.core.extras = {"n_hat": (0, 0, 1)}
 
-**Directly on the geometry** — required for ``azimuthal_reference``;
+**Directly on the geometry** — required for ``azimuth``;
 also works for ``surface_normal``:
 
 .. code-block:: python
 
    psic2.core.solver._geom.surface_normal = (0, 0, 1)
-   psic2.core.solver._geom.azimuthal_reference = (1, 0, 0)
+   psic2.core.solver._geom.azimuth = (1, 0, 0)
 
 The argument is a length-3 sequence of Miller indices.  ``(0, 0, 0)``
 is rejected with ``ValueError``; the default is ``None`` (not set).
@@ -290,7 +290,7 @@ Override a fixed-axis default value
 ------------------------------------
 
 Each ``fixed_<axis>`` mode (for example ``fourcv`` ``fixed_chi``,
-``psic`` ``fixed_chi_vertical``, ``fixed_alpha_i_fixed_chi_fixed_phi``)
+``psic`` ``fixed_chi_vertical``, ``fixed_incidence_fixed_chi_fixed_phi``)
 carries a default scalar value baked into the geometry's YAML
 definition.  Constraint values are immutable, so changing a default
 replaces the underlying
@@ -312,8 +312,8 @@ Override several stages at once on a multi-fix mode:
 .. code-block:: python
 
    psic2.core.solver.update_mode_constraints(
-       "fixed_alpha_i_fixed_chi_fixed_phi",
-       chi=15.0, phi=30.0, alpha_i=5.0,
+       "fixed_incidence_fixed_chi_fixed_phi",
+       chi=15.0, phi=30.0, incidence=5.0,
    )
 
 Operate on the currently active mode by omitting ``mode_name``:
@@ -338,7 +338,7 @@ Persistent overrides vs. per-call reference scalars
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Two distinct routes touch reference-constraint scalars
-(``psi``, ``alpha_i``, ``beta_out``) on modes that expose them:
+(``psi``, ``incidence``, ``emergence``) on modes that expose them:
 
 * :meth:`~hklpy2_solvers.ad_hoc_solver.AdHocSolver.update_mode_constraints`
   is the **persistent** route — the new value becomes the mode's

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
   "Topic :: Scientific/Engineering",
 ]
 dependencies = [
-  "ad_hoc_diffractometer>=0.11.1",
+  "ad_hoc_diffractometer>=0.11.2",
   "diffcalc-core",
   "hklpy2>=0.7.1",
   "numpy",

--- a/src/hklpy2_solvers/ad_hoc_solver.py
+++ b/src/hklpy2_solvers/ad_hoc_solver.py
@@ -26,7 +26,7 @@ from ad_hoc_diffractometer.mode import (
     ConstraintViolation,
     EwaldSphereViolation,
 )
-from ad_hoc_diffractometer.reference import exit_angle as _ref_exit_angle
+from ad_hoc_diffractometer.reference import emergence_angle as _ref_emergence_angle
 from ad_hoc_diffractometer.reference import incidence_angle as _ref_incidence_angle
 from ad_hoc_diffractometer.reference import natural_psi as _ref_natural_psi
 from ad_hoc_diffractometer.reference import naz_angle as _ref_naz_angle
@@ -51,7 +51,7 @@ try:
 except PackageNotFoundError:  # pragma: no cover - defensive
     _BACKEND_VERSION = "unknown"
 
-_INPUT_EXTRA_NAMES: frozenset[str] = frozenset({"n_hat", "psi", "alpha_i", "beta_out", "h2", "k2", "l2"})
+_INPUT_EXTRA_NAMES: frozenset[str] = frozenset({"n_hat", "psi", "incidence", "emergence", "h2", "k2", "l2"})
 """Names of mode-extra parameters supplied by the user (vs. solver outputs)."""
 
 # ---------------------------------------------------------------------------
@@ -90,7 +90,7 @@ _GEOMETRY_STATE_OMIT_KEYS: frozenset[str] = frozenset({"active_sample", "samples
 manages independently and must not round-trip through the solver
 state (avoids double-restore of samples and wavelength)."""
 
-_REFERENCE_EXTRA_NAMES: frozenset[str] = frozenset({"psi", "alpha_i", "beta_out"})
+_REFERENCE_EXTRA_NAMES: frozenset[str] = frozenset({"psi", "incidence", "emergence"})
 """Reference-constraint scalar extras (set via ``ConstraintSet.with_constraint_values``)."""
 
 _DOUBLE_DIFF_EXTRA_NAMES: tuple[str, ...] = ("h2", "k2", "l2")
@@ -319,7 +319,7 @@ class AdHocSolver(SolverBase):
 
         Drawn from the underlying mode's ``extras`` dict (filtered to the
         names the user is expected to supply: ``n_hat``, ``psi``,
-        ``alpha_i``, ``beta_out``, ``h2``, ``k2``, ``l2``) plus the
+        ``incidence``, ``emergence``, ``h2``, ``k2``, ``l2``) plus the
         scalar name of the active :class:`ReferenceConstraint` if it
         names one of those inputs and is not already listed.
 
@@ -382,7 +382,7 @@ class AdHocSolver(SolverBase):
 
         * ``n_hat``  -> ``geometry.surface_normal`` (length-3 sequence or
           ``None``).
-        * ``psi``, ``alpha_i``, ``beta_out`` -> rebuild the active
+        * ``psi``, ``incidence``, ``emergence`` -> rebuild the active
           :class:`ConstraintSet` via
           :meth:`~ad_hoc_diffractometer.mode.ConstraintSet.with_constraint_values`
           so the :class:`ReferenceConstraint` carries the new scalar
@@ -416,7 +416,7 @@ class AdHocSolver(SolverBase):
                 except TypeError:
                     self._geom.surface_normal = None
 
-        # Reference-constraint scalar (psi / alpha_i / beta_out).
+        # Reference-constraint scalar (psi / incidence / emergence).
         # ``ConstraintSet.with_constraint_values`` (upstream
         # ad_hoc_diffractometer >= 0.11.1, :issue:`114`) returns a fresh
         # ConstraintSet with the named scalar replaced, preserving order,
@@ -438,7 +438,7 @@ class AdHocSolver(SolverBase):
         """Override default values of one or more constraints on a mode.
 
         Each ``fixed_<axis>`` mode (e.g. ``fourcv`` ``fixed_chi``, ``psic``
-        ``fixed_alpha_i_vertical``) carries a default scalar value baked
+        ``fixed_incidence_vertical``) carries a default scalar value baked
         into the geometry's YAML definition.  Constraint values are
         immutable; this method replaces the named mode's
         :class:`~ad_hoc_diffractometer.mode.ConstraintSet` with a fresh
@@ -458,8 +458,8 @@ class AdHocSolver(SolverBase):
             :class:`~ad_hoc_diffractometer.mode.SampleConstraint`,
             :class:`~ad_hoc_diffractometer.mode.DetectorConstraint`, or
             :class:`~ad_hoc_diffractometer.mode.ReferenceConstraint` in
-            the mode.  Reference-constraint scalars (``psi``, ``alpha_i``,
-            ``beta_out``) can also be updated through the per-call
+            the mode.  Reference-constraint scalars (``psi``, ``incidence``,
+            ``emergence``) can also be updated through the per-call
             :attr:`extras` setter; this method is the route for persistent
             overrides of fixed-axis defaults.
 
@@ -479,8 +479,8 @@ class AdHocSolver(SolverBase):
         Override several stages at once on a multi-fix mode::
 
             solver.update_mode_constraints(
-                "fixed_alpha_i_fixed_chi_fixed_phi",
-                chi=15.0, phi=30.0, alpha_i=5.0,
+                "fixed_incidence_fixed_chi_fixed_phi",
+                chi=15.0, phi=30.0, incidence=5.0,
             )
 
         Operate on the currently active mode::
@@ -796,8 +796,8 @@ class AdHocSolver(SolverBase):
     # "Derived quantities" section of the AdHoc user guide.
     # ------------------------------------------------------------------
 
-    def exit_angle(self, angles: dict[str, float] | None = None) -> float:
-        """Exit angle β_out (deg).
+    def emergence_angle(self, angles: dict[str, float] | None = None) -> float:
+        """Emergence angle (deg).
 
         Requires :attr:`~ad_hoc_diffractometer.diffractometer.AdHocDiffractometer.surface_normal`
         to be set on the underlying geometry.
@@ -808,10 +808,10 @@ class AdHocSolver(SolverBase):
             Motor angles in degrees keyed by real-axis name.  ``None``
             (default) means use the geometry's current angles.
         """
-        return float(_ref_exit_angle(self._geom, angles=self._normalize_angles(angles)))
+        return float(_ref_emergence_angle(self._geom, angles=self._normalize_angles(angles)))
 
     def incidence_angle(self, angles: dict[str, float] | None = None) -> float:
-        """Incidence angle α_i (deg).
+        """Incidence angle (deg).
 
         Requires :attr:`~ad_hoc_diffractometer.diffractometer.AdHocDiffractometer.surface_normal`
         to be set on the underlying geometry.
@@ -827,11 +827,11 @@ class AdHocSolver(SolverBase):
     def natural_psi(self, h: float, k: float, l: float) -> float | None:  # noqa: E741
         """Natural azimuthal angle ψ (deg) for reflection ``(h, k, l)`` from UB.
 
-        Uses ``UB @ (h, k, l)`` and ``UB @ azimuthal_reference``; **no
+        Uses ``UB @ (h, k, l)`` and ``UB @ azimuth``; **no
         motor angles enter the calculation**.  Returns ``None`` when the
-        reflection is parallel to the azimuthal reference (ψ undefined).
+        reflection is parallel to the azimuth reference (ψ undefined).
 
-        Requires :attr:`~ad_hoc_diffractometer.diffractometer.AdHocDiffractometer.azimuthal_reference`
+        Requires :attr:`~ad_hoc_diffractometer.diffractometer.AdHocDiffractometer.azimuth`
         to be set on the underlying geometry.
         """
         result = _ref_natural_psi(self._geom, float(h), float(k), float(l))
@@ -865,7 +865,7 @@ class AdHocSolver(SolverBase):
     def psi_angle(self, angles: dict[str, float] | None = None) -> float:
         """Azimuthal angle ψ (deg) from motor positions.
 
-        Requires :attr:`~ad_hoc_diffractometer.diffractometer.AdHocDiffractometer.azimuthal_reference`
+        Requires :attr:`~ad_hoc_diffractometer.diffractometer.AdHocDiffractometer.azimuth`
         to be set on the underlying geometry.
 
         PARAMETERS

--- a/tests/test_ad_hoc_solver.py
+++ b/tests/test_ad_hoc_solver.py
@@ -753,11 +753,11 @@ def test_forward_inverse_roundtrip(parms, context):
         pytest.param(
             dict(
                 geometry="psic",
-                mode="fixed_alpha_i_vertical",
-                expected=["n_hat", "alpha_i", "beta_out"],
+                mode="fixed_incidence_vertical",
+                expected=["n_hat", "incidence", "emergence"],
             ),
             does_not_raise(),
-            id="psic fixed_alpha_i_vertical exposes alpha_i+beta_out",
+            id="psic fixed_incidence_vertical exposes incidence+emergence",
         ),
         pytest.param(
             dict(
@@ -780,20 +780,20 @@ def test_forward_inverse_roundtrip(parms, context):
         pytest.param(
             dict(
                 geometry="sixc",
-                mode="alpha_eq_beta_zaxis",
-                expected=["n_hat", "alpha_i", "beta_out"],
+                mode="specular_zaxis",
+                expected=["n_hat", "incidence", "emergence"],
             ),
             does_not_raise(),
-            id="sixc alpha_eq_beta_zaxis exposes alpha_i+beta_out",
+            id="sixc specular_zaxis exposes incidence+emergence",
         ),
         pytest.param(
             dict(
                 geometry="s2d2",
                 mode="reflectivity",
-                expected=["n_hat", "alpha_i", "beta_out"],
+                expected=["n_hat", "incidence", "emergence"],
             ),
             does_not_raise(),
-            id="s2d2 reflectivity exposes alpha_i+beta_out",
+            id="s2d2 reflectivity exposes incidence+emergence",
         ),
     ],
 )
@@ -822,12 +822,12 @@ def test_extra_axis_names(parms, context):
         pytest.param(
             dict(
                 geometry="psic",
-                mode="fixed_alpha_i_vertical",
-                values={"alpha_i": 1.5, "n_hat": [1, 0, 0]},
-                check={"alpha_i": 1.5, "n_hat": (1.0, 0.0, 0.0)},
+                mode="fixed_incidence_vertical",
+                values={"incidence": 1.5, "n_hat": [1, 0, 0]},
+                check={"incidence": 1.5, "n_hat": (1.0, 0.0, 0.0)},
             ),
             does_not_raise(),
-            id="set alpha_i and n_hat on psic fixed_alpha_i_vertical",
+            id="set incidence and n_hat on psic fixed_incidence_vertical",
         ),
         pytest.param(
             dict(
@@ -920,8 +920,8 @@ def test_forward_with_extras(parms, context):
     """Forward calculation honours extras for implemented modes.
 
     .. note::
-        ``ad_hoc_diffractometer`` 0.11.0 marks the surface (``alpha_i``,
-        ``beta_out``, ``alpha_eq_beta``) and ``fixed_psi_*`` modes as
+        ``ad_hoc_diffractometer`` 0.11.0 marks the surface (``incidence``,
+        ``emergence``, ``specular``) and ``fixed_psi_*`` modes as
         not yet implemented.  This test exercises the ``double_diffraction``
         family because it is implemented and uses extras (``h2``, ``k2``,
         ``l2``).  When upstream implements the surface modes, additional
@@ -1790,8 +1790,8 @@ def test_ub_setter_default_lattice(parms, context):
         pytest.param(
             dict(
                 geometry="psic",
-                mode="fixed_alpha_i_vertical",
-                values={"n_hat": 0, "alpha_i": 0, "beta_out": 0},
+                mode="fixed_incidence_vertical",
+                values={"n_hat": 0, "incidence": 0, "emergence": 0},
                 expected_normal=None,
             ),
             does_not_raise(),
@@ -1886,7 +1886,7 @@ def _ref_helper_solver(*, configure: bool = True) -> AdHocSolver:
     """Build a psic AdHocSolver wired for reference-helper tests.
 
     When ``configure`` is False the geometry is left without
-    ``azimuthal_reference`` / ``surface_normal`` so that failure
+    ``azimuth`` / ``surface_normal`` so that failure
     paths in the upstream helpers can be exercised.
     """
     import ad_hoc_diffractometer as ahd
@@ -1896,7 +1896,7 @@ def _ref_helper_solver(*, configure: bool = True) -> AdHocSolver:
     ahd.ub_identity(solver._geom.sample)
     solver.set_reals(REF_HELPER_ANGLES)
     if configure:
-        solver._geom.azimuthal_reference = (0, 0, 1)
+        solver._geom.azimuth = (0, 0, 1)
         solver._geom.surface_normal = (1, 1, 6)
     return solver
 
@@ -1933,12 +1933,12 @@ def _ref_helper_solver(*, configure: bool = True) -> AdHocSolver:
         ),
         pytest.param(
             dict(
-                method="exit_angle",
+                method="emergence_angle",
                 args=(REF_HELPER_ANGLES,),
                 expected=pytest.approx(19.456294998006513, abs=1e-9),
             ),
             does_not_raise(),
-            id="exit_angle with explicit angles dict",
+            id="emergence_angle with explicit angles dict",
         ),
         pytest.param(
             dict(
@@ -1974,7 +1974,7 @@ def _ref_helper_solver(*, configure: bool = True) -> AdHocSolver:
                 expected=None,
             ),
             does_not_raise(),
-            id="natural_psi returns None when reflection parallel to azimuthal reference",
+            id="natural_psi returns None when reflection parallel to azimuth reference",
         ),
         pytest.param(
             dict(
@@ -1999,7 +1999,7 @@ def _ref_helper_solver(*, configure: bool = True) -> AdHocSolver:
 def test_reference_helpers(parms, context):
     """Cover all six reference-helper methods plus their failure paths.
 
-    Verifies that ``AdHocSolver.{psi,incidence,exit,naz}_angle``,
+    Verifies that ``AdHocSolver.{psi,incidence,emergence,naz}_angle``,
     ``omega_pseudo`` and ``natural_psi`` forward to
     :mod:`ad_hoc_diffractometer.reference`, accept the documented
     inputs (dict-of-angles, default ``None``, or ``h, k, l``), and that
@@ -2022,8 +2022,8 @@ def test_reference_helpers(parms, context):
     [
         pytest.param(
             dict(method="psi_angle"),
-            pytest.raises(ValueError, match=re.escape("azimuthal_reference")),
-            id="psi_angle without azimuthal_reference raises upstream ValueError",
+            pytest.raises(ValueError, match=re.escape("azimuth")),
+            id="psi_angle without azimuth raises upstream ValueError",
         ),
         pytest.param(
             dict(method="incidence_angle"),
@@ -2031,9 +2031,9 @@ def test_reference_helpers(parms, context):
             id="incidence_angle without surface_normal raises upstream ValueError",
         ),
         pytest.param(
-            dict(method="exit_angle"),
+            dict(method="emergence_angle"),
             pytest.raises(ValueError, match=re.escape("surface_normal")),
-            id="exit_angle without surface_normal raises upstream ValueError",
+            id="emergence_angle without surface_normal raises upstream ValueError",
         ),
         pytest.param(
             dict(method="naz_angle"),
@@ -2045,7 +2045,7 @@ def test_reference_helpers(parms, context):
 def test_reference_helpers_missing_geometry_config(parms, context):
     """Preconditions documented on each wrapper are enforced by upstream.
 
-    Wrappers do **not** silently default ``azimuthal_reference`` or
+    Wrappers do **not** silently default ``azimuth`` or
     ``surface_normal``; with neither set, the upstream call raises a
     ``ValueError`` mentioning the missing attribute.  This test pins
     that behaviour so users get a useful diagnostic rather than a
@@ -2509,7 +2509,7 @@ def _exercise_psi_scalar_write(geometry: str, mode: str) -> None:
             id="creator bootstrap on psic",
         ),
         pytest.param(
-            dict(exercise=_exercise_direct_n_hat_write, args=("psic", "fixed_alpha_i_vertical")),
+            dict(exercise=_exercise_direct_n_hat_write, args=("psic", "fixed_incidence_vertical")),
             does_not_raise(),
             id="adapter extras setter routes n_hat to surface_normal",
         ),
@@ -2537,7 +2537,7 @@ def test_adapter_does_not_emit_n_hat_placeholder_warning(parms, context):
     :class:`UserWarning` whenever ``ConstraintSet.extras['n_hat']`` is
     overwritten with a real value, because the actual surface-normal
     vector lives on the geometry attribute (``surface_normal`` or
-    ``azimuthal_reference``), not in the per-mode extras dict.
+    ``azimuth``), not in the per-mode extras dict.
 
     The adapter must never trip this warning from its own code: it
     routes ``n_hat`` to ``geometry.surface_normal`` (see


### PR DESCRIPTION
- closes #117

## Summary

Adopt the `ad_hoc_diffractometer` v0.11.2 API, which bundled two
breaking-rename PRs upstream.  Pre-v1.0, so no deprecation shims.

**PR #298** — `azimuthal_reference` → `azimuth`.

**PR #299** — `exit_angle` → `emergence_angle`; `alpha_i`/`beta_out`
extras → `incidence`/`emergence`; surface modes →
`fixed_incidence_*` / `fixed_emergence_*` / `specular_*`.

This also aligns the surface-angle terminology across all three
packages — `hklpy2`, `ad_hoc_diffractometer`, and `hklpy2_solvers`
now share `incidence` / `emergence` / `azimuth` / `psi`.

## Changes

- `pyproject.toml`: dependency floor `>=0.11.1` → `>=0.11.2`.
- `src/hklpy2_solvers/ad_hoc_solver.py`: imports, extra-name sets,
  method/mode renames, docstrings (glyphs replaced with words).
- `tests/test_ad_hoc_solver.py`: mode/extra/method names, error-match
  strings, parametrize ids.
- `docs/source/{geometries,guide_ad_hoc}.rst`: mode tables, recipes,
  examples.  The diffcalc section (`a_eq_b` / `bin_eq_bout`) is left
  unchanged — that is diffcalc's own vocabulary.
- `RELEASE_NOTES.rst`: Breaking Changes, Documentation, Maintenance
  entries.

## Verification

Tested against the released `ad_hoc_diffractometer==0.11.2` from PyPI
in a throwaway venv:

- `pytest ./tests`: 344 passed, 1 skipped.
- 100% line + branch coverage.
- `pre-commit run --all-files`: all hooks pass.

Agent: OpenCode (argo/claudeopus48)