### PR TITLE
Change diffcalc-core dependency to optional

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -29,6 +29,11 @@ describe future plans.
 
     Expected release: tba
 
+    New Features
+    ~~~~~~~~~~~~
+
+    * Make ``diffcalc-core`` an optional dependency (group ``diffcalc``).  :issue:`119`
+
 0.3.4
 ######
 

--- a/docs/source/guide_diffcalc.rst
+++ b/docs/source/guide_diffcalc.rst
@@ -15,6 +15,14 @@ six-circle geometry, :ref:`diffcalc_4S_2D <geometry.diffcalc_4S_2D>` (the
 ``psic`` geometry described by You 1999),
 with 23 operating modes.
 
+.. note::
+
+   ``diffcalc-core`` is an optional backend.  Install it with
+   ``pip install hklpy2-solvers[diffcalc]`` or
+   ``conda install -c paulscherrerinstitute diffcalc-core``.  See
+   :ref:`install` for details.  Requesting the ``diffcalc`` solver
+   without the backend raises an error explaining how to install it.
+
 Create a diffractometer
 -----------------------
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -9,7 +9,6 @@ Requirements
 
 - Python 3.10 or newer
 - `hklpy2 <https://blueskyproject.io/hklpy2/>`_
-- `diffcalc-core <https://github.com/DiamondLightSource/diffcalc-core>`_
 
 Install from PyPI
 -----------------
@@ -17,6 +16,27 @@ Install from PyPI
 .. code-block:: bash
 
    pip install hklpy2-solvers
+
+.. note:: Includes the ``ad_hoc`` solver.
+
+Optional ``diffcalc`` solver
+----------------------------
+
+The ``diffcalc`` solver requires the optional
+`diffcalc-core <https://github.com/DiamondLightSource/diffcalc-core>`_
+backend.  The ``ad_hoc`` solver works without it.  Install the backend
+with either pip or conda:
+
+.. code-block:: bash
+
+   pip install hklpy2-solvers[diffcalc]
+
+.. code-block:: bash
+
+   conda install -c paulscherrerinstitute diffcalc-core
+
+If the ``diffcalc`` solver is requested without ``diffcalc-core``
+installed, a clear error explains how to install it.
 
 Install for development
 -----------------------

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -31,7 +31,8 @@ Available solvers
    * - ``diffcalc``
      - :ref:`diffcalc_4S_2D <geometry.diffcalc_4S_2D>`
      - You (1999) six-circle geometry via
-       `diffcalc-core <https://github.com/DiamondLightSource/diffcalc-core>`_.
+       `diffcalc-core <https://github.com/DiamondLightSource/diffcalc-core>`_
+       (optional backend; see :ref:`install`).
        23 operating modes.
    * - ``ad_hoc``
      - :ref:`fourcv <geometry.fourcv>`, :ref:`fourch <geometry.fourch>`,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,16 +26,16 @@ classifiers = [
 ]
 dependencies = [
   "ad_hoc_diffractometer>=0.11.2",
-  "diffcalc-core",
   "hklpy2>=0.7.1",
   "numpy",
 ]
 
 [project.optional-dependencies]
-all = ["hklpy2-solvers[dev,doc]"]
+all = ["hklpy2-solvers[dev,diffcalc,doc]"]
 dev = [
   "build",
   "coverage",
+  "diffcalc-core",
   "isort",
   "packaging",
   "pre-commit",
@@ -43,6 +43,7 @@ dev = [
   "pytest-cov",
   "ruff",
 ]
+diffcalc = ["diffcalc-core"]
 doc = [
   "myst-nb",
   "pydata-sphinx-theme",

--- a/src/hklpy2_solvers/diffcalc_solver.py
+++ b/src/hklpy2_solvers/diffcalc_solver.py
@@ -18,17 +18,39 @@ from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _pkg_version
 from typing import Any
 
-from diffcalc.hkl.calc import HklCalculation
-from diffcalc.hkl.constraints import Constraints
-from diffcalc.hkl.geometry import Position
-from diffcalc.ub.calc import UBCalculation
-from diffcalc.util import DiffcalcException
 from hklpy2.backends.base import SolverBase
 from hklpy2.backends.typing import ReflectionDict
 from hklpy2.exceptions import SolverError
 from hklpy2.typing import KeyValueMap, Matrix3x3, NamedFloatDict
 
+# ``diffcalc-core`` is an optional dependency (:issue:`119`).  Import it
+# lazily so that this module can be imported (and the ``diffcalc`` solver
+# entry point can be advertised by hklpy2) even when the backend is not
+# installed.  The failure is deferred to :meth:`DiffcalcSolver.__init__`,
+# which raises a clear, actionable :class:`SolverError`.
+try:
+    from diffcalc.hkl.calc import HklCalculation
+    from diffcalc.hkl.constraints import Constraints
+    from diffcalc.hkl.geometry import Position
+    from diffcalc.ub.calc import UBCalculation
+    from diffcalc.util import DiffcalcException
+
+    _DIFFCALC_IMPORT_ERROR: ImportError | None = None
+except ImportError as exc:  # exercised by test_diffcalc_optional via import simulation
+    HklCalculation = Constraints = Position = UBCalculation = None  # type: ignore[assignment]
+    DiffcalcException = None  # type: ignore[assignment]
+    _DIFFCALC_IMPORT_ERROR = exc
+
 logger = logging.getLogger(__name__)
+
+INSTALL_HINT = (
+    "The 'diffcalc' solver requires the optional 'diffcalc-core' package, "
+    "which is not installed.  Install it with one of:\n"
+    "    pip install hklpy2-solvers[diffcalc]\n"
+    "    pip install diffcalc-core\n"
+    "    conda install -c paulscherrerinstitute diffcalc-core"
+)
+"""Actionable message shown when ``diffcalc-core`` is not installed."""
 
 GEOMETRY_NAME = "diffcalc_4S_2D"
 """Geometry name exposed to hklpy2."""
@@ -135,6 +157,8 @@ class DiffcalcSolver(SolverBase):
     version = _BACKEND_VERSION
 
     def __init__(self, geometry: str = GEOMETRY_NAME, **kwargs: Any) -> None:
+        if _DIFFCALC_IMPORT_ERROR is not None:
+            raise SolverError(INSTALL_HINT) from _DIFFCALC_IMPORT_ERROR
         if geometry != GEOMETRY_NAME:
             raise SolverError(
                 f"DiffcalcSolver supports only the {GEOMETRY_NAME!r} geometry, received {geometry!r}."

--- a/tests/test_cross_validation.py
+++ b/tests/test_cross_validation.py
@@ -88,6 +88,10 @@ import numpy as np
 import pytest
 
 pytest.importorskip("tests._hkl_library_probe")
+# The ``diffcalc`` groups below cross-validate against the optional
+# ``diffcalc-core`` backend (:issue:`119`); skip the whole module when
+# it is not installed, mirroring the libhkl probe above.
+pytest.importorskip("diffcalc")
 
 import hklpy2  # noqa: E402  (import after probe so skips fire first)
 from ad_hoc_diffractometer import Lattice as _AdHocLattice  # noqa: E402

--- a/tests/test_diffcalc_optional.py
+++ b/tests/test_diffcalc_optional.py
@@ -1,0 +1,162 @@
+# Copyright (c) 2025-2026 UChicago Argonne, LLC
+# SPDX-License-Identifier: LicenseRef-UChicago-Argonne-LLC-License
+"""Behaviour when the optional ``diffcalc-core`` backend is absent (:issue:`119`).
+
+These tests simulate ``diffcalc-core`` not being importable, within a
+single environment that *does* have the backend installed.  They assert
+that:
+
+* the solver module's guarded import block tolerates a missing backend
+  (the ``except ImportError`` path);
+* :class:`~hklpy2_solvers.diffcalc_solver.DiffcalcSolver` raises a clear,
+  actionable :class:`hklpy2.exceptions.SolverError` when the backend is
+  absent;
+* the package and the ``ad_hoc`` solver are unaffected.
+
+The ``except ImportError`` path is exercised by loading a *fresh, private
+copy* of the module under a throwaway name (with ``import diffcalc``
+blocked) so the real, cached
+:mod:`hklpy2_solvers.diffcalc_solver` module is never mutated and other
+test modules keep their original class objects.  The ``__init__`` guard
+branch is exercised by monkeypatching the module's
+``_DIFFCALC_IMPORT_ERROR`` sentinel, which ``pytest`` restores
+automatically.
+"""
+
+import builtins
+import importlib.util
+import re
+import sys
+from contextlib import nullcontext as does_not_raise
+
+import pytest
+from hklpy2.exceptions import SolverError
+
+import hklpy2_solvers.diffcalc_solver as diffcalc_solver
+
+
+def _load_module_without_diffcalc():
+    """Import a private copy of ``diffcalc_solver`` with ``diffcalc`` blocked.
+
+    Loads the module source under a throwaway module name so the real
+    cached module is untouched.  Returns the freshly loaded module,
+    whose ``_DIFFCALC_IMPORT_ERROR`` is set because the guarded
+    ``from diffcalc...`` imports raised ``ImportError``.
+    """
+    real_import = builtins.__import__
+
+    def blocked_import(name, *args, **kwargs):
+        if name == "diffcalc" or name.startswith("diffcalc."):
+            raise ImportError("simulated: diffcalc-core not installed")
+        return real_import(name, *args, **kwargs)
+
+    spec = importlib.util.spec_from_file_location(
+        "hklpy2_solvers._diffcalc_solver_no_backend",
+        diffcalc_solver.__file__,
+    )
+    module = importlib.util.module_from_spec(spec)
+
+    saved = {
+        name: mod
+        for name, mod in sys.modules.items()
+        if name == "diffcalc" or name.startswith("diffcalc.")
+    }
+    for name in saved:
+        del sys.modules[name]
+    builtins.__import__ = blocked_import
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        builtins.__import__ = real_import
+        sys.modules.update(saved)
+    return module
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(check="error_recorded"),
+            does_not_raise(),
+            id="guarded import records the ImportError",
+        ),
+        pytest.param(
+            dict(check="names_are_none"),
+            does_not_raise(),
+            id="guarded names bound to None when backend absent",
+        ),
+    ],
+)
+def test_module_imports_without_backend(parms, context):
+    with context:
+        module = _load_module_without_diffcalc()
+        if parms["check"] == "error_recorded":
+            assert module._DIFFCALC_IMPORT_ERROR is not None
+            assert isinstance(module._DIFFCALC_IMPORT_ERROR, ImportError)
+        else:
+            assert module.UBCalculation is None
+            assert module.Constraints is None
+            assert module.Position is None
+            assert module.HklCalculation is None
+            assert module.DiffcalcException is None
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(match="pip install hklpy2-solvers[diffcalc]"),
+            pytest.raises(
+                SolverError,
+                match=re.escape("pip install hklpy2-solvers[diffcalc]"),
+            ),
+            id="error names the pip extra install route",
+        ),
+        pytest.param(
+            dict(match="conda install -c paulscherrerinstitute diffcalc-core"),
+            pytest.raises(
+                SolverError,
+                match=re.escape("conda install -c paulscherrerinstitute diffcalc-core"),
+            ),
+            id="error names the conda install route",
+        ),
+    ],
+)
+def test_instantiation_raises_when_backend_absent(parms, context, monkeypatch):
+    with context:
+        # Simulate the backend being unavailable without mutating the
+        # real module's class objects: only the sentinel is patched, and
+        # pytest restores it after the test.
+        monkeypatch.setattr(
+            diffcalc_solver,
+            "_DIFFCALC_IMPORT_ERROR",
+            ImportError("simulated: diffcalc-core not installed"),
+        )
+        diffcalc_solver.DiffcalcSolver()
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(),
+            does_not_raise(),
+            id="ad_hoc solver and entry-point discovery unaffected",
+        ),
+    ],
+)
+def test_ad_hoc_unaffected_when_backend_absent(parms, context, monkeypatch):
+    with context:
+        import hklpy2
+
+        monkeypatch.setattr(
+            diffcalc_solver,
+            "_DIFFCALC_IMPORT_ERROR",
+            ImportError("simulated: diffcalc-core not installed"),
+        )
+        # ``diffcalc`` is still advertised by hklpy2's entry points even
+        # when the backend cannot be imported.
+        assert "diffcalc" in hklpy2.solvers()
+        # The ad_hoc solver builds normally.
+        diffractometer = hklpy2.creator(geometry="fourcv", solver="ad_hoc", name="ah")
+        assert diffractometer is not None

--- a/tests/test_diffcalc_optional.py
+++ b/tests/test_diffcalc_optional.py
@@ -56,11 +56,7 @@ def _load_module_without_diffcalc():
     )
     module = importlib.util.module_from_spec(spec)
 
-    saved = {
-        name: mod
-        for name, mod in sys.modules.items()
-        if name == "diffcalc" or name.startswith("diffcalc.")
-    }
+    saved = {name: mod for name, mod in sys.modules.items() if name == "diffcalc" or name.startswith("diffcalc.")}
     for name in saved:
         del sys.modules[name]
     builtins.__import__ = blocked_import

--- a/tests/test_diffcalc_solver.py
+++ b/tests/test_diffcalc_solver.py
@@ -9,7 +9,18 @@ from contextlib import nullcontext as does_not_raise
 import pytest
 from hklpy2.exceptions import SolverError
 
+from hklpy2_solvers import diffcalc_solver
 from hklpy2_solvers.diffcalc_solver import _MODES, GEOMETRY_NAME, PSEUDO_AXES, REAL_AXES, DiffcalcSolver
+
+# The ``diffcalc`` solver depends on the optional ``diffcalc-core``
+# backend (:issue:`119`).  When that backend is not installed, the
+# backend-present tests in this module cannot run; skip the whole module.
+# The dedicated absent-backend behaviour is covered separately in
+# ``test_diffcalc_optional.py``.
+pytestmark = pytest.mark.skipif(
+    diffcalc_solver._DIFFCALC_IMPORT_ERROR is not None,
+    reason="optional 'diffcalc-core' backend is not installed",
+)
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/test_docs_guides.py
+++ b/tests/test_docs_guides.py
@@ -110,13 +110,30 @@ def _run_guide(rst_path):
 # ---------------------------------------------------------------------------
 
 
+def _diffcalc_backend_available():
+    """True when the optional ``diffcalc-core`` backend imports (:issue:`119`)."""
+    from hklpy2_solvers import diffcalc_solver
+
+    return diffcalc_solver._DIFFCALC_IMPORT_ERROR is None
+
+
 def _discover_guides():
-    """Yield ``pytest.param`` for each how-to guide on disk."""
+    """Yield ``pytest.param`` for each how-to guide on disk.
+
+    The ``guide_diffcalc`` guide executes code that needs the optional
+    ``diffcalc-core`` backend (:issue:`119`); mark it skipped when the
+    backend is not installed so the rest of the guide suite still runs.
+    """
+    marks = []
+    if not _diffcalc_backend_available():
+        marks = [pytest.mark.skip(reason="optional 'diffcalc-core' backend is not installed")]
     for rst_path in sorted(GUIDES_DIR.glob(GUIDE_GLOB)):
+        guide_marks = marks if rst_path.stem == "guide_diffcalc" else []
         yield pytest.param(
             dict(rst_path=rst_path),
             does_not_raise(),
             id=rst_path.stem,
+            marks=guide_marks,
         )
 
 


### PR DESCRIPTION
- closes #119

## Summary

Make `diffcalc-core` an optional dependency rather than a required one. The `ad_hoc` solver and the package import work without the backend; the `diffcalc` solver works when the optional backend is installed, and otherwise fails at use-time with a clear, actionable error.

## Changes

- **Packaging** (`pyproject.toml`): remove `diffcalc-core` from required `dependencies`; add optional group `diffcalc = ["diffcalc-core"]`; add it to `dev` (so CI exercises the backend-present path) and to the `all` aggregate.
- **Solver** (`diffcalc_solver.py`): guard the top-level `diffcalc` imports; defer the failure to `DiffcalcSolver.__init__`, which raises `SolverError` with both pip and conda install instructions when the backend is absent.
- **Tests**: new `test_diffcalc_optional.py` covers the guarded-import path, the `__init__` guard (pip and conda hints), and that `ad_hoc` + entry-point discovery are unaffected — simulating absence within a single backend-present environment. Existing diffcalc tests skip when the backend is absent.
- **Docs**: `install.rst`, `usage.rst`, `guide_diffcalc.rst` present `diffcalc-core` as optional with pip and conda routes.
- **Release notes**: terse `New Features` entry.

## Verification

- `pytest ./tests` → 349 passed, 1 skipped (libhkl-dependent cross-validation; pre-existing), 100% line+branch coverage, in a clean Python 3.12 env at declared dependency floors (hklpy2 0.7.2, ad-hoc-diffractometer 0.11.2, diffcalc-core 0.4.0).
- `pre-commit run --all-files` → all hooks pass.

## Notes

- Optional is the intended permanent posture (see issue).
- Follow-up #120 tracks an unrelated single-line-imports style standardization, deliberately kept out of this PR.

Agent: OpenCode (claudeopus48)
