### PR TITLE
Standardize on single-line imports (ruff isort)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -219,16 +219,15 @@ dynamic expression would hide drift between them.
   - Format & Lint: `pre-commit run --all-files` (preferred; see note below)
   - Test: `pytest ./tests`
 
-### `make style` vs `pre-commit run --all-files`
+### Import style
 
-`make style` runs `isort --sl` before `pre-commit`.  `isort --sl` (single-line
-mode) and ruff's built-in isort (`I` rule) disagree on whether to split
-multi-symbol imports from the same module onto separate lines.  This causes
-`make style` to report a ruff failure even when the file is already correct.
+Ruff's isort (`I` rule) is the single authority for import sorting, and it is
+configured with `force-single-line = true` under `[tool.ruff.lint.isort]`, so
+each imported symbol appears on its own line.  `make style` and `pre-commit
+run --all-files` both enforce this via ruff; there is no separate standalone
+`isort` invocation.
 
-**Use `pre-commit run --all-files` directly** as the authoritative lint/format
-check.  Ruff's isort is the style enforced by CI; `isort --sl` in the
-`Makefile` is a legacy convenience that conflicts with it.
+**Use `pre-commit run --all-files`** as the authoritative lint/format check.
 
 ### pre-commit on NFS home directories
 

--- a/Makefile
+++ b/Makefile
@@ -20,14 +20,11 @@ docs ::
 
 doc :: docs
 
-isort:
-	isort --sl ./src
-
 pre:
 	pre-commit run --all-files
 	ruff check .
 
-style :: isort pre
+style :: pre
 
 realclean :: clean
 	/bin/rm -rf ./docs/build

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -34,6 +34,11 @@ describe future plans.
 
     * Make ``diffcalc-core`` an optional dependency (group ``diffcalc``).  :issue:`119`
 
+    Maintenance
+    ~~~~~~~~~~~
+
+    * Enforce single-line imports via ruff isort ``force-single-line``.  :issue:`120`
+
 0.3.4
 ######
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ dev = [
   "build",
   "coverage",
   "diffcalc-core",
-  "isort",
   "packaging",
   "pre-commit",
   "pytest",
@@ -89,12 +88,6 @@ version-file = "src/hklpy2_solvers/_version.py"
 [tool.hatch.build.targets.wheel]
 packages = ["src/hklpy2_solvers"]
 
-[tool.isort]
-profile = "black"
-force_single_line = true
-line_length = 115
-src_paths = ["."]
-
 [tool.pytest.ini_options]
 addopts = ["--import-mode=importlib"]
 markers = [
@@ -129,3 +122,6 @@ select = [
   "UP",  # pyupgrade
   "W",   # pycodestyle warnings
 ]
+
+[tool.ruff.lint.isort]
+force-single-line = true

--- a/scripts/stamp_release.py
+++ b/scripts/stamp_release.py
@@ -50,7 +50,8 @@ import subprocess
 import sys
 from pathlib import Path
 
-from packaging.version import InvalidVersion, Version
+from packaging.version import InvalidVersion
+from packaging.version import Version
 
 RELEASE_NOTES = Path(__file__).parent.parent / "RELEASE_NOTES.rst"
 

--- a/src/hklpy2_solvers/ad_hoc_solver.py
+++ b/src/hklpy2_solvers/ad_hoc_solver.py
@@ -20,12 +20,10 @@ from typing import Any
 
 import ad_hoc_diffractometer as ahd
 import numpy as np
-from ad_hoc_diffractometer.mode import (
-    OPTIONAL,
-    REQUIRED,
-    ConstraintViolation,
-    EwaldSphereViolation,
-)
+from ad_hoc_diffractometer.mode import OPTIONAL
+from ad_hoc_diffractometer.mode import REQUIRED
+from ad_hoc_diffractometer.mode import ConstraintViolation
+from ad_hoc_diffractometer.mode import EwaldSphereViolation
 from ad_hoc_diffractometer.reference import emergence_angle as _ref_emergence_angle
 from ad_hoc_diffractometer.reference import incidence_angle as _ref_incidence_angle
 from ad_hoc_diffractometer.reference import natural_psi as _ref_natural_psi
@@ -36,7 +34,9 @@ from ad_hoc_diffractometer.refinement import refine_lattice_bl1967
 from hklpy2.backends.base import SolverBase
 from hklpy2.backends.typing import ReflectionDict
 from hklpy2.exceptions import SolverError
-from hklpy2.typing import KeyValueMap, Matrix3x3, NamedFloatDict
+from hklpy2.typing import KeyValueMap
+from hklpy2.typing import Matrix3x3
+from hklpy2.typing import NamedFloatDict
 
 logger = logging.getLogger(__name__)
 

--- a/src/hklpy2_solvers/diffcalc_solver.py
+++ b/src/hklpy2_solvers/diffcalc_solver.py
@@ -21,7 +21,9 @@ from typing import Any
 from hklpy2.backends.base import SolverBase
 from hklpy2.backends.typing import ReflectionDict
 from hklpy2.exceptions import SolverError
-from hklpy2.typing import KeyValueMap, Matrix3x3, NamedFloatDict
+from hklpy2.typing import KeyValueMap
+from hklpy2.typing import Matrix3x3
+from hklpy2.typing import NamedFloatDict
 
 # ``diffcalc-core`` is an optional dependency (:issue:`119`).  Import it
 # lazily so that this module can be imported (and the ``diffcalc`` solver

--- a/tests/test_ad_hoc_solver.py
+++ b/tests/test_ad_hoc_solver.py
@@ -10,7 +10,9 @@ from contextlib import nullcontext as does_not_raise
 import pytest
 from hklpy2.exceptions import SolverError
 
-from hklpy2_solvers.ad_hoc_solver import DEFAULT_GEOMETRY, PSEUDO_AXES, AdHocSolver
+from hklpy2_solvers.ad_hoc_solver import DEFAULT_GEOMETRY
+from hklpy2_solvers.ad_hoc_solver import PSEUDO_AXES
+from hklpy2_solvers.ad_hoc_solver import AdHocSolver
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -2070,7 +2072,8 @@ def _add_psic_user_mode(solver, name="my_psic_mode"):
     contract.
     """
     import ad_hoc_diffractometer as ahd  # noqa: F401
-    from ad_hoc_diffractometer.mode import ConstraintSet, SampleConstraint
+    from ad_hoc_diffractometer.mode import ConstraintSet
+    from ad_hoc_diffractometer.mode import SampleConstraint
 
     solver._geom.modes[name] = ConstraintSet(
         constraints=[
@@ -2198,7 +2201,8 @@ def test_simulator_from_config_round_trip(parms, context):
     Core's cached mode (a documented upstream caching pattern).
     """
     import hklpy2
-    from ad_hoc_diffractometer.mode import ConstraintSet, SampleConstraint
+    from ad_hoc_diffractometer.mode import ConstraintSet
+    from ad_hoc_diffractometer.mode import SampleConstraint
     from hklpy2.run_utils import simulator_from_config
 
     sim = hklpy2.creator(solver="ad_hoc", geometry=parms["geometry"], name="adhoc_persist")

--- a/tests/test_cross_validation.py
+++ b/tests/test_cross_validation.py
@@ -95,7 +95,8 @@ pytest.importorskip("diffcalc")
 
 import hklpy2  # noqa: E402  (import after probe so skips fire first)
 from ad_hoc_diffractometer import Lattice as _AdHocLattice  # noqa: E402
-from hklpy2.exceptions import NoForwardSolutions, SolverError  # noqa: E402
+from hklpy2.exceptions import NoForwardSolutions  # noqa: E402
+from hklpy2.exceptions import SolverError  # noqa: E402
 
 pytestmark = pytest.mark.cross_validation
 

--- a/tests/test_diffcalc_solver.py
+++ b/tests/test_diffcalc_solver.py
@@ -10,7 +10,11 @@ import pytest
 from hklpy2.exceptions import SolverError
 
 from hklpy2_solvers import diffcalc_solver
-from hklpy2_solvers.diffcalc_solver import _MODES, GEOMETRY_NAME, PSEUDO_AXES, REAL_AXES, DiffcalcSolver
+from hklpy2_solvers.diffcalc_solver import _MODES
+from hklpy2_solvers.diffcalc_solver import GEOMETRY_NAME
+from hklpy2_solvers.diffcalc_solver import PSEUDO_AXES
+from hklpy2_solvers.diffcalc_solver import REAL_AXES
+from hklpy2_solvers.diffcalc_solver import DiffcalcSolver
 
 # The ``diffcalc`` solver depends on the optional ``diffcalc-core``
 # backend (:issue:`119`).  When that backend is not installed, the


### PR DESCRIPTION
- closes #120

## Summary

Standardize import sorting on single-line imports (one symbol per line), enforced by ruff's isort, resolving the prior conflict between the dead standalone `[tool.isort]` config and ruff's enforced style.

## Changes

- `pyproject.toml`: add `[tool.ruff.lint.isort] force-single-line = true`; remove the stale `[tool.isort]` block; drop the now-unused `isort` dev dependency.
- `Makefile`: remove the conflicting `isort --sl` target; `style` now depends only on `pre` (pre-commit + ruff).
- `AGENTS.md`: replace the obsolete "make style vs pre-commit" note with an "Import style" note naming ruff as the single authority.
- Mechanical reformat (`ruff check --select I --fix`) across `src`, `tests`, and `scripts`.
- `RELEASE_NOTES.rst`: terse `Maintenance` entry.

## Verification

- `pytest ./tests` → 349 passed, 1 skipped (libhkl-dependent cross-validation; pre-existing), 100% line+branch coverage, in a clean Python 3.12 env at declared dependency floors.
- `pre-commit run --all-files` → all hooks pass.
- `ruff format --check` and `ruff check` with the newer ruff (CI parity) → clean.

Agent: OpenCode (claudeopus48)
