### PR TITLE
Enable ad_hoc reference-constraint modes (adopt v0.11.3)

### DIFF
--- a/.github/workflows/cross-validation.yml
+++ b/.github/workflows/cross-validation.yml
@@ -81,16 +81,16 @@ jobs:
 
       - name: Install pip-only dependencies
         # ``diffcalc-core`` is the only runtime dep not on conda-forge.
-        # If a conda-forge feedstock later falls behind the
-        # ``pyproject.toml`` floor, add ``pip install --upgrade`` lines
-        # for the affected packages here.
         #
-        # ``ad-hoc-diffractometer`` is upgraded from PyPI because the
-        # conda-forge feedstock trails the ``pyproject.toml`` floor
-        # (>=0.11.2); remove once conda-forge catches up (:issue:`117`).
+        # ``ad_hoc_diffractometer`` is force-upgraded from PyPI on every
+        # run: conda-forge publishes hours-to-days after PyPI, so the
+        # feedstock routinely trails the ``pyproject.toml`` floor.  This
+        # is a standing policy, not a per-release workaround; ``--upgrade``
+        # always pulls the newest PyPI release (which satisfies the floor),
+        # so no version literal needs bumping here.
         run: |
           pip install diffcalc-core
-          pip install --upgrade "ad_hoc_diffractometer>=0.11.2"
+          pip install --upgrade ad_hoc_diffractometer
 
       - name: Install hklpy2_solvers (editable, no deps)
         # Use --no-deps because all runtime deps are already provided

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -33,6 +33,12 @@ describe future plans.
     ~~~~~
 
     * Fix broken RST indentation in ``psic``/``sixc`` mode tables.  :issue:`123`
+    * Route ``n_hat`` extra to the mode's required reference vector.  :issue:`123`
+
+    Maintenance
+    ~~~~~~~~~~~
+
+    * Bump ``ad_hoc_diffractometer`` floor to ``>=0.11.3``.  :issue:`123`
 
 0.3.5
 ######

--- a/docs/source/geometries.rst
+++ b/docs/source/geometries.rst
@@ -37,6 +37,15 @@ followed by any per-call scalar extras (``psi``, ``incidence``,
 ``emergence``).  See :ref:`guide_ad_hoc.reference_vector` for the
 recipes.
 
+.. note::
+
+   Reference-constraint modes (those listing ``psi``, ``incidence``,
+   ``emergence``, or ``surface_normal``/``azimuth``) require
+   ``ad_hoc_diffractometer >= 0.11.3`` and the corresponding reference
+   vector to be set (via the ``n_hat`` extra); otherwise
+   :meth:`~hklpy2_solvers.ad_hoc_solver.AdHocSolver.forward` raises
+   :class:`~hklpy2.exceptions.SolverError`.
+
 .. _geometry.fourcv:
 
 fourcv

--- a/docs/source/guide_ad_hoc.rst
+++ b/docs/source/guide_ad_hoc.rst
@@ -253,8 +253,10 @@ directly:
 Two ways to set the vector
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-**Through the** ``extras`` **dict** — works only for ``n_hat`` and
-only for modes that consume ``surface_normal``:
+**Through the** ``extras`` **dict** — the ``n_hat`` extra routes to
+whichever attribute the active mode requires
+(``surface_normal`` for surface modes, ``azimuth`` for psi / naz
+modes), so it works for every reference-constraint mode:
 
 .. code-block:: python
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
   "Topic :: Scientific/Engineering",
 ]
 dependencies = [
-  "ad_hoc_diffractometer>=0.11.2",
+  "ad_hoc_diffractometer>=0.11.3",
   "hklpy2>=0.7.1",
   "numpy",
 ]

--- a/src/hklpy2_solvers/ad_hoc_solver.py
+++ b/src/hklpy2_solvers/ad_hoc_solver.py
@@ -361,7 +361,9 @@ class AdHocSolver(SolverBase):
             return out
         for name in self.extra_axis_names:
             if name == "n_hat":
-                out[name] = self._geom.surface_normal
+                # Mirror the setter's routing (:issue:`123`).
+                target = self._geom.required_reference_vector
+                out[name] = None if target is None else getattr(self._geom, target)
             elif name in _REFERENCE_EXTRA_NAMES:
                 rc = getattr(mode_obj, "reference_constraint", None)
                 if rc is not None and rc.name == name:
@@ -401,20 +403,22 @@ class AdHocSolver(SolverBase):
         if mode_obj is None:  # pragma: no cover - mode setter guarantees object
             return
 
-        # Surface-normal vector.  ``hklpy2.Core`` defaults vector extras
-        # to the scalar ``0`` during ``update_solver()`` (see
-        # :issue:`81`); treat any non-iterable value as "unset" so the
-        # adapter can be constructed via ``hklpy2.creator`` for modes
-        # that expose ``n_hat`` (e.g. ``zaxis``).
+        # ``n_hat`` routes to the attribute the active mode reads, named
+        # by ``required_reference_vector`` (``surface_normal``, ``azimuth``,
+        # or ``None``); this flips ``is_implemented()`` for psi modes
+        # (:issue:`123`).  Non-iterable values (e.g. ``hklpy2.Core``'s
+        # scalar-``0`` default, :issue:`81`) mean "unset".
         if "n_hat" in values:
-            v = values["n_hat"]
-            if v is None:
-                self._geom.surface_normal = None
-            else:
-                try:
-                    self._geom.surface_normal = tuple(float(x) for x in v)
-                except TypeError:
-                    self._geom.surface_normal = None
+            target = self._geom.required_reference_vector
+            if target is not None:  # pragma: no branch - n_hat implies a target
+                v = values["n_hat"]
+                if v is None:
+                    setattr(self._geom, target, None)
+                else:
+                    try:
+                        setattr(self._geom, target, tuple(float(x) for x in v))
+                    except TypeError:
+                        setattr(self._geom, target, None)
 
         # Reference-constraint scalar (psi / incidence / emergence).
         # ``ConstraintSet.with_constraint_values`` (upstream

--- a/tests/test_ad_hoc_solver.py
+++ b/tests/test_ad_hoc_solver.py
@@ -1503,6 +1503,106 @@ def test_psic_forward_inverse(parms, context):
     [
         pytest.param(
             dict(
+                mode="fixed_psi_vertical",
+                n_hat=(0, 0, 1),
+                # ``psi`` is fixed by UB + (h, k, l); target the natural
+                # value so the validation filter admits the solutions.
+                psi="natural",
+                hkl={"h": 1, "k": 0, "l": 0},
+                min_solutions=1,
+            ),
+            does_not_raise(),
+            id="psic fixed_psi_vertical with natural psi yields solutions",
+        ),
+        pytest.param(
+            dict(
+                mode="fixed_psi_vertical",
+                n_hat=(0, 0, 1),
+                # Wrong psi target: filtered out, empty solution set.
+                psi=0.0,
+                hkl={"h": 1, "k": 0, "l": 0},
+                min_solutions=0,
+            ),
+            does_not_raise(),
+            id="psic fixed_psi_vertical with wrong psi yields no solutions",
+        ),
+        pytest.param(
+            dict(
+                mode="fixed_incidence_vertical",
+                n_hat=(0, 0, 1),
+                incidence=0.0,
+                hkl={"h": 1, "k": 0, "l": 0},
+                min_solutions=1,
+                # Surface modes return many constraint-satisfying
+                # branches; do not pin the inverse to the input hkl.
+                roundtrip=False,
+            ),
+            does_not_raise(),
+            id="psic fixed_incidence_vertical yields solutions",
+        ),
+        pytest.param(
+            dict(
+                # No reference vector set: the upstream solver is not
+                # implemented for the mode, surfaced as SolverError.
+                mode="fixed_psi_vertical",
+                n_hat=None,
+                hkl={"h": 1, "k": 0, "l": 0},
+                min_solutions=0,
+            ),
+            pytest.raises(
+                SolverError,
+                match=re.escape("forward(): mode 'fixed_psi_vertical' is not yet implemented"),
+            ),
+            id="psic fixed_psi_vertical without reference vector raises",
+        ),
+    ],
+)
+def test_psic_reference_constraint_modes_forward(parms, context):
+    """Reference-constraint modes solve once their reference vector is set.
+
+    Regression for :issue:`123` (upstream BCDA-APS#304): with
+    ``ad_hoc_diffractometer >= 0.11.3`` the ``ReferenceConstraint``
+    solvers are implemented, and the adapter routes ``n_hat`` to the
+    mode's required reference-vector attribute
+    (``azimuth`` for psi modes, ``surface_normal`` for surface modes),
+    flipping ``mode.is_implemented()`` to ``True`` so ``forward()``
+    returns real solutions.  When no reference vector is set the
+    upstream solver remains unimplemented and the adapter surfaces a
+    :class:`~hklpy2.exceptions.SolverError`.
+    """
+    with context:
+        solver = _make_solver_with_ub(geometry="psic", mode=parms["mode"])
+        if parms["n_hat"] is not None:
+            solver.extras = {"n_hat": parms["n_hat"]}
+        psi = parms.get("psi")
+        if psi == "natural":
+            psi = solver.natural_psi(**parms["hkl"])
+        if psi is not None:
+            solver.extras = {"psi": psi}
+        if "incidence" in parms:
+            solver.extras = {"incidence": parms["incidence"]}
+        # The mode must be reachable (reference vector routed) whenever a
+        # reference vector was supplied.
+        if parms["n_hat"] is not None:
+            assert solver._geom.mode.is_implemented(solver._geom)
+        with warnings.catch_warnings():
+            # A wrong psi target legitimately warns and returns []; that
+            # path is exercised by the ``min_solutions == 0`` case.
+            warnings.simplefilter("ignore", UserWarning)
+            solutions = solver.forward(parms["hkl"])
+        assert len(solutions) >= parms["min_solutions"]
+        if parms["min_solutions"] >= 1 and parms.get("roundtrip", True):
+            hkl = solver.inverse(solutions[0])
+            assert abs(hkl["h"] - parms["hkl"]["h"]) < 0.01
+            assert abs(hkl["k"] - parms["hkl"]["k"]) < 0.01
+            assert abs(hkl["l"] - parms["hkl"]["l"]) < 0.01
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(
                 reflections=[],
             ),
             does_not_raise(),
@@ -1784,7 +1884,7 @@ def test_ub_setter_default_lattice(parms, context):
                 geometry="fourcv",
                 mode="fixed_psi",
                 values={"n_hat": 0},
-                expected_normal=None,
+                expected_vector=None,
             ),
             does_not_raise(),
             id="scalar 0 n_hat is normalised to None",
@@ -1794,30 +1894,40 @@ def test_ub_setter_default_lattice(parms, context):
                 geometry="psic",
                 mode="fixed_incidence_vertical",
                 values={"n_hat": 0, "incidence": 0, "emergence": 0},
-                expected_normal=None,
+                expected_vector=None,
             ),
             does_not_raise(),
             id="full scalar-default extras dict (Core push) accepted",
         ),
         pytest.param(
             dict(
+                geometry="psic",
+                mode="fixed_incidence_vertical",
+                values={"n_hat": (1, 0, 0)},
+                expected_vector=(1.0, 0.0, 0.0),
+            ),
+            does_not_raise(),
+            id="3-iterable n_hat routes to surface_normal (surface mode)",
+        ),
+        pytest.param(
+            dict(
                 geometry="fourcv",
                 mode="fixed_psi",
                 values={"n_hat": (1, 0, 0)},
-                expected_normal=(1.0, 0.0, 0.0),
+                expected_vector=(1.0, 0.0, 0.0),
             ),
             does_not_raise(),
-            id="3-iterable n_hat still works after fix",
+            id="3-iterable n_hat routes to azimuth (psi mode)",
         ),
         pytest.param(
             dict(
                 geometry="fourcv",
                 mode="fixed_psi",
                 values={"n_hat": None},
-                expected_normal=None,
+                expected_vector=None,
             ),
             does_not_raise(),
-            id="None n_hat still clears surface_normal after fix",
+            id="None n_hat clears the reference vector",
         ),
     ],
 )
@@ -1831,12 +1941,19 @@ def test_extras_n_hat_scalar_default(parms, context):
     non-iterable input, breaking ``hklpy2.creator(solver='ad_hoc',
     geometry='zaxis')``.  The fix normalises any non-iterable
     ``n_hat`` value to ``None`` (treated as "no surface normal set").
+
+    Extended for :issue:`123`: ``n_hat`` routes to whichever
+    reference-vector attribute the active mode requires
+    (``surface_normal`` for surface modes, ``azimuth`` for psi modes),
+    so the assertion reads back through
+    ``required_reference_vector``.
     """
     with context:
         solver = AdHocSolver(parms["geometry"])
         solver.mode = parms["mode"]
         solver.extras = parms["values"]
-        assert solver._geom.surface_normal == parms["expected_normal"]
+        target = solver._geom.required_reference_vector
+        assert getattr(solver._geom, target) == parms["expected_vector"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- closes #123

## Summary

Adopt `ad_hoc_diffractometer` v0.11.3, which implements the
`ReferenceConstraint` solvers (upstream
[BCDA-APS/ad_hoc_diffractometer#304](https://github.com/BCDA-APS/ad_hoc_diffractometer/issues/304)).
The `psi` / `incidence` / `emergence` / `specular` modes now compute
once their reference vector is set, so `psic` / `fixed_psi_vertical`
(the case reported in #123) returns solutions instead of raising
`NotImplementedError`.

### Two defects behind #123

1. **Docs rendering** (already fixed on `main` in 48ec627): PR #118 left
   `psic`/`sixc` mode-table rows with 6-space cell indentation, which
   broke the `list-table` directive and dropped the entire `psic` table
   from the rendered page — making `fixed_psi_vertical` appear missing.
2. **Runtime** (this PR): the modes were exposed but the upstream
   `ReferenceConstraint` solver was an unfinished stub.  Fixed upstream
   in v0.11.3; this PR adopts it and fixes an adapter routing bug so the
   modes are reachable.

## Changes

- `src/hklpy2_solvers/ad_hoc_solver.py`: route the `n_hat` extra to the
  mode's `required_reference_vector` attribute (`azimuth` for psi/naz,
  `surface_normal` for surface modes) in both the `extras` getter and
  setter, so `mode.is_implemented()` flips True and `forward()` solves.
- `pyproject.toml`: bump `ad_hoc_diffractometer` floor to `>=0.11.3`.
- `.github/workflows/cross-validation.yml`: always force-upgrade
  `ad_hoc_diffractometer` from PyPI (conda-forge perennially lags PyPI;
  reframed as standing policy, no version literal to bump on releases).
- `tests/test_ad_hoc_solver.py`: parametrized forward tests for psic
  reference-constraint modes (matched/mismatched psi, surface mode,
  missing reference vector raises `SolverError`); updated the
  `n_hat`-routing regression test for the corrected behavior.
- `docs/source/{geometries,guide_ad_hoc}.rst`: document the `>=0.11.3`
  requirement and the corrected `n_hat` routing.
- `RELEASE_NOTES.rst`: Fixes + Maintenance entries.

## Verification

- `pytest ./tests`: 995 passed, 30 xfailed, 6 xpassed.
- 100% line + branch coverage.
- `pre-commit run --all-files`: clean.
- `sphinx -b html -W`: builds; `fixed_psi_vertical` and siblings render.
- `forward()` for `psic`/`fixed_psi_vertical` returns real solutions
  (verified against released PyPI `ad_hoc_diffractometer==0.11.3`).

Agent: OpenCode (argo/claudeopus48)
