### PR TITLE
fix #125 clarify reference-vector-required error in ad_hoc forward

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -29,6 +29,11 @@ describe future plans.
 
     Expected release: tba
 
+    Fixes
+    ~~~~~
+
+    * Raise a clear error naming ``n_hat`` when a reference mode lacks its reference vector.  :issue:`125`
+
 0.3.6
 ######
 

--- a/docs/source/guide_ad_hoc.rst
+++ b/docs/source/guide_ad_hoc.rst
@@ -274,6 +274,22 @@ The argument is a length-3 sequence of Miller indices.  ``(0, 0, 0)``
 is rejected with ``ValueError``; the default is ``None`` (not set).
 Clear an attribute by assigning ``None``.
 
+.. important::
+
+   You **must** set the reference vector *before* calling
+   :meth:`~hklpy2_solvers.ad_hoc_solver.AdHocSolver.forward`.  A
+   reference-constraint mode *is* implemented, but it is not **ready**
+   to solve until its reference vector (``n̂``) is supplied — that extra
+   information is part of the mode's definition.  A premature
+   ``forward()`` therefore raises::
+
+      SolverError: forward(): mode 'fixed_psi_vertical' for geometry
+      'psic' requires the reference vector to be set first.  Set the
+      'psi' reference direction via the 'n_hat' extra, ...
+
+   Set ``n_hat`` (or the geometry attribute directly) using either
+   recipe above, then call ``forward()`` again.  See :issue:`125`.
+
 .. caution::
 
    ``ad_hoc_diffractometer >= 0.11.1`` emits a ``UserWarning`` when

--- a/src/hklpy2_solvers/ad_hoc_solver.py
+++ b/src/hklpy2_solvers/ad_hoc_solver.py
@@ -550,12 +550,52 @@ class AdHocSolver(SolverBase):
         k = float(pseudos["k"])
         l = float(pseudos["l"])  # noqa: E741
 
+        self._raise_if_reference_vector_unset()
+
         try:
             results = self._geom.forward(h, k, l)
         except (EwaldSphereViolation, ConstraintViolation, ValueError, NotImplementedError) as exc:
             raise SolverError(str(exc)) from exc
 
         return results
+
+    def _raise_if_reference_vector_unset(self) -> None:
+        """Raise a clear :class:`SolverError` for an unset reference vector.
+
+        Reference-constraint modes (``psi`` / ``incidence`` / ``emergence``
+        / ``specular``) *are* implemented, but they are not **ready** to
+        solve until their reference vector — ``azimuth`` for ``psi``,
+        ``surface_normal`` for the others — is set on the geometry: that
+        vector is part of the mode's definition.  While it is unset the
+        underlying library reports ``mode.is_implemented(geometry)`` as
+        ``False`` and raises a misleading *"mode ... is not yet
+        implemented"* ``NotImplementedError`` (:issue:`125`).
+
+        Detect that specific situation here and raise a ``SolverError``
+        that tells the user to set the ``n_hat`` extra, distinguishing
+        "implemented but not ready" from a mode that is genuinely
+        unimplemented upstream.
+        """
+        mode_obj = self._geom.mode
+        if mode_obj is None:  # pragma: no cover - mode setter guarantees object
+            return
+        rc = getattr(mode_obj, "reference_constraint", None)
+        if rc is None:
+            return
+        target = self._geom.required_reference_vector
+        # A reference constraint with no required vector (e.g. ``naz``) or a
+        # vector that is already set is left to the library; only the
+        # actionable "vector unset" case is intercepted here.
+        if target is None or getattr(self._geom, target) is not None:
+            return
+        raise SolverError(
+            f"forward(): mode {self._mode!r} for geometry "
+            f"{self._geom.name!r} requires the reference vector to be set "
+            f"first.  Set the {rc.name!r} reference direction via the "
+            f"'n_hat' extra, e.g. diffractometer.core.extras = "
+            f"{{'n_hat': (0, 0, 1)}} (routed to geometry.{target}), "
+            "then call forward() again."
+        )
 
     @classmethod
     def geometries(cls) -> list[str]:

--- a/tests/test_ad_hoc_solver.py
+++ b/tests/test_ad_hoc_solver.py
@@ -922,12 +922,13 @@ def test_forward_with_extras(parms, context):
     """Forward calculation honours extras for implemented modes.
 
     .. note::
-        ``ad_hoc_diffractometer`` 0.11.0 marks the surface (``incidence``,
-        ``emergence``, ``specular``) and ``fixed_psi_*`` modes as
-        not yet implemented.  This test exercises the ``double_diffraction``
-        family because it is implemented and uses extras (``h2``, ``k2``,
-        ``l2``).  When upstream implements the surface modes, additional
-        cases should be added here.
+        This test exercises the ``double_diffraction`` family because it
+        uses extras (``h2``, ``k2``, ``l2``) that route directly into the
+        mode without a reference vector.  The reference-constraint surface
+        and ``fixed_psi_*`` modes (implemented upstream in
+        ``ad_hoc_diffractometer >= 0.11.3``) are covered separately by
+        :func:`test_psic_reference_constraint_modes_forward` and
+        :func:`test_forward_reference_vector_required`.
 
         The ``hkl = (1, 1, 1)`` primary with ``(h2, k2, l2) = (0, 1, 1)``
         secondary is chosen because it lies inside the Ewald sphere for
@@ -947,6 +948,54 @@ def test_forward_with_extras(parms, context):
                 assert stored == tuple(float(x) for x in value)
             else:
                 assert stored == value
+
+
+@pytest.mark.parametrize(
+    "parms, context",
+    [
+        pytest.param(
+            dict(
+                geometry="fourcv",
+                mode="fixed_psi",
+                pseudos={"h": 1.0, "k": 1.0, "l": 0.0},
+            ),
+            pytest.raises(
+                SolverError,
+                match=re.escape(
+                    "forward(): mode 'fixed_psi' for geometry 'fourcv' "
+                    "requires the reference vector to be set first.  Set the "
+                    "'psi' reference direction via the 'n_hat' extra"
+                ),
+            ),
+            id="fourcv fixed_psi without n_hat raises clear SolverError",
+        ),
+        pytest.param(
+            dict(
+                geometry="psic",
+                mode="bisecting_vertical",
+                pseudos={"h": 0.0, "k": 1.0, "l": 1.0},
+            ),
+            does_not_raise(),
+            id="non-reference mode solves without n_hat",
+        ),
+    ],
+)
+def test_forward_reference_vector_required(parms, context):
+    """Reference modes need ``n_hat`` set or raise a clear error (:issue:`125`).
+
+    ``ad_hoc_diffractometer >= 0.11.3`` implements the
+    ``ReferenceConstraint`` solvers, but ``mode.is_implemented(geometry)``
+    only returns ``True`` once the reference vector (``azimuth`` for
+    ``psi`` modes) is set.  Without it the library raises a misleading
+    *"mode ... is not yet implemented"*; :class:`AdHocSolver` intercepts
+    that case and raises an actionable :class:`SolverError`.  Modes with
+    no reference constraint are unaffected.
+    """
+    with context:
+        solver = _make_solver_with_ub(parms["geometry"])
+        solver.mode = parms["mode"]
+        solutions = solver.forward(parms["pseudos"])
+        assert len(solutions) >= 1
 
 
 @pytest.mark.parametrize(
@@ -1543,7 +1592,9 @@ def test_psic_forward_inverse(parms, context):
         pytest.param(
             dict(
                 # No reference vector set: the upstream solver is not
-                # implemented for the mode, surfaced as SolverError.
+                # implemented for the mode; the adapter intercepts the
+                # misleading "not yet implemented" error and raises a
+                # clear, actionable SolverError instead (:issue:`125`).
                 mode="fixed_psi_vertical",
                 n_hat=None,
                 hkl={"h": 1, "k": 0, "l": 0},
@@ -1551,7 +1602,11 @@ def test_psic_forward_inverse(parms, context):
             ),
             pytest.raises(
                 SolverError,
-                match=re.escape("forward(): mode 'fixed_psi_vertical' is not yet implemented"),
+                match=re.escape(
+                    "forward(): mode 'fixed_psi_vertical' for geometry 'psic' "
+                    "requires the reference vector to be set first.  Set the "
+                    "'psi' reference direction via the 'n_hat' extra"
+                ),
             ),
             id="psic fixed_psi_vertical without reference vector raises",
         ),


### PR DESCRIPTION
- closes #125

## How

Reference-constraint modes (`psi`/`incidence`/`emergence`/`specular`)
are implemented in `ad_hoc_diffractometer >=0.11.3` but are not *ready*
to solve until their reference vector (`n_hat`) is set — that vector is
part of the mode's definition.  While unset, the upstream library
reports `mode.is_implemented(geometry)` as `False` and raises a
misleading *"mode ... is not yet implemented"* `NotImplementedError`.

`AdHocSolver.forward()` now intercepts that specific case and raises an
actionable `SolverError` naming `n_hat`, distinguishing "implemented but
not ready" from a genuinely unimplemented mode.  Non-reference modes and
constraints with no required vector (e.g. `naz`) are untouched.

- Added/updated parametrized tests (100% coverage on the solver module;
  full suite green against 0.11.3).
- Documented in the `ad_hoc` guide that the reference vector must be set
  before `forward()`, using the "implemented but not ready" framing.

Agent: OpenCode (argo/claudeopus48)