### PR TITLE
Prepare repo for move to bluesky org

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -59,24 +59,6 @@ jobs:
       - name: Build Sphinx documentation
         run: python3 -m sphinx -b html docs/source docs/build/html
 
-      - name: Generate root redirect page
-        run: |
-          mkdir -p docs/build/redirect
-          cat > docs/build/redirect/index.html <<'EOF'
-          <!DOCTYPE html>
-          <html>
-            <head>
-              <meta charset="utf-8">
-              <meta http-equiv="refresh" content="0; url=latest/">
-              <link rel="canonical" href="latest/">
-              <title>Redirecting to latest documentation</title>
-            </head>
-            <body>
-              <p>Redirecting to <a href="latest/">latest documentation</a>…</p>
-            </body>
-          </html>
-          EOF
-
       - name: Upload docs as workflow artifact
         uses: actions/upload-artifact@v7
         with:
@@ -93,13 +75,13 @@ jobs:
           destination_dir: latest
           keep_files: true
 
-      - name: Deploy root redirect to gh-pages (main push)
+      - name: Deploy to gh-pages — root/ (main push, custom domain)
         uses: peaceiris/actions-gh-pages@v4
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages
-          publish_dir: docs/build/redirect
+          publish_dir: docs/build/html
           destination_dir: .
           keep_files: true
 
@@ -221,16 +203,6 @@ jobs:
           git pull --rebase origin gh-pages
           git push
 
-      - name: Deploy root redirect to gh-pages (tag push)
-        uses: peaceiris/actions-gh-pages@v4
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_branch: gh-pages
-          publish_dir: docs/build/redirect
-          destination_dir: .
-          keep_files: true
-
       - name: Deploy on manual trigger
         uses: peaceiris/actions-gh-pages@v4
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.deploy == 'true'
@@ -241,12 +213,12 @@ jobs:
           destination_dir: latest
           keep_files: true
 
-      - name: Deploy root redirect on manual trigger
+      - name: Deploy to gh-pages — root/ (manual trigger, custom domain)
         uses: peaceiris/actions-gh-pages@v4
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.deploy == 'true'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages
-          publish_dir: docs/build/redirect
+          publish_dir: docs/build/html
           destination_dir: .
           keep_files: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -155,7 +155,7 @@ jobs:
 
           gh_pages = Path("gh-pages-clone")
           switcher_path = Path(os.environ["SWITCHER"])
-          base_url = "https://prjemian.github.io/hklpy2_solvers"
+          base_url = "https://blueskyproject.io/hklpy2_solvers"
           ref = os.environ.get("GITHUB_REF", "")
           tag_version = ref[len("refs/tags/"):] if ref.startswith("refs/tags/") else ""
 

--- a/README.md
+++ b/README.md
@@ -1,40 +1,40 @@
 # hklpy2_solvers
 
-[![Release](https://img.shields.io/github/v/release/prjemian/hklpy2_solvers)](https://github.com/prjemian/hklpy2_solvers/releases)
-[![Tag](https://img.shields.io/github/v/tag/prjemian/hklpy2_solvers)](https://github.com/prjemian/hklpy2_solvers/tags)
+[![Release](https://img.shields.io/github/v/release/bluesky/hklpy2_solvers)](https://github.com/bluesky/hklpy2_solvers/releases)
+[![Tag](https://img.shields.io/github/v/tag/bluesky/hklpy2_solvers)](https://github.com/bluesky/hklpy2_solvers/tags)
 [![PyPi](https://img.shields.io/pypi/v/hklpy2_solvers.svg)](https://pypi.python.org/pypi/hklpy2_solvers)
 [![Conda Package](https://img.shields.io/badge/package-hklpy2_solvers-green.svg)](https://anaconda.org/channels/conda-forge/packages/hklpy2_solvers/overview)
 [![Conda Version](https://anaconda.org/conda-forge/hklpy2_solvers/badges/version.svg)](https://anaconda.org/channels/conda-forge/packages/hklpy2_solvers/overview)
 [![Conda Downloads](https://anaconda.org/conda-forge/hklpy2_solvers/badges/downloads.svg)](https://anaconda.org/channels/conda-forge/packages/hklpy2_solvers/overview)
 [![Conda Platforms](https://anaconda.org/conda-forge/hklpy2_solvers/badges/platforms.svg)](https://anaconda.org/channels/conda-forge/packages/hklpy2_solvers/overview)
-[![Coverage Status](https://coveralls.io/repos/github/prjemian/hklpy2_solvers/badge.svg?branch=main)](https://coveralls.io/github/prjemian/hklpy2_solvers?branch=main)
-[![Documentation](https://img.shields.io/badge/docs-blue)](https://prjemian.github.io/hklpy2_solvers/latest/)
-[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/prjemian/hklpy2_solvers)
+[![Coverage Status](https://coveralls.io/repos/github/bluesky/hklpy2_solvers/badge.svg?branch=main)](https://coveralls.io/github/bluesky/hklpy2_solvers?branch=main)
+[![Documentation](https://img.shields.io/badge/docs-blue)](https://blueskyproject.io/hklpy2_solvers/latest/)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/bluesky/hklpy2_solvers)
 [![License: ANL](https://img.shields.io/badge/license-ANL-brightgreen)](LICENSE)
 
-Solvers for the [hklpy2](https://github.com/prjemian/hklpy2) package.
+Solvers for the [hklpy2](https://github.com/bluesky/hklpy2) package.
 
 <table>
     <tr>
         <td>
             <b>Solvers</b>
             <p>
-                <a href="https://prjemian.github.io/hklpy2_solvers/latest/geometries.html">Geometries</a>
-                · <a href="https://prjemian.github.io/hklpy2_solvers/latest/guide_ad_hoc.html">ad_hoc</a>
-                · <a href="https://prjemian.github.io/hklpy2_solvers/latest/guide_diffcalc.html">diffcalc</a>
+                <a href="https://blueskyproject.io/hklpy2_solvers/latest/geometries.html">Geometries</a>
+                · <a href="https://blueskyproject.io/hklpy2_solvers/latest/guide_ad_hoc.html">ad_hoc</a>
+                · <a href="https://blueskyproject.io/hklpy2_solvers/latest/guide_diffcalc.html">diffcalc</a>
             </p>
         </td>
         <td>
             <b>User Guide</b>
             <p>
-                <a href="https://prjemian.github.io/hklpy2_solvers/latest/guides.html">Guides</a>
-                · <a href="https://prjemian.github.io/hklpy2_solvers/latest/install.html">Installation</a>
-                · <a href="https://prjemian.github.io/hklpy2_solvers/latest/api/hklpy2_solvers/">API</a>
-                · <a href="https://prjemian.github.io/hklpy2_solvers">documentation</a>
-                · <a href="https://github.com/prjemian/hklpy2_solvers">source</a>
-                · <a href="https://prjemian.github.io/hklpy2_solvers/latest/release_notes.html">Releases</a>
-                · <a href="https://prjemian.github.io/hklpy2_solvers/latest/license.html">License</a>
-                · <a href="https://prjemian.github.io/hklpy2_solvers/latest/genindex.html">Index</a>
+                <a href="https://blueskyproject.io/hklpy2_solvers/latest/guides.html">Guides</a>
+                · <a href="https://blueskyproject.io/hklpy2_solvers/latest/install.html">Installation</a>
+                · <a href="https://blueskyproject.io/hklpy2_solvers/latest/api/hklpy2_solvers/">API</a>
+                · <a href="https://blueskyproject.io/hklpy2_solvers">documentation</a>
+                · <a href="https://github.com/bluesky/hklpy2_solvers">source</a>
+                · <a href="https://blueskyproject.io/hklpy2_solvers/latest/release_notes.html">Releases</a>
+                · <a href="https://blueskyproject.io/hklpy2_solvers/latest/license.html">License</a>
+                · <a href="https://blueskyproject.io/hklpy2_solvers/latest/genindex.html">Index</a>
             </p>
         </td>
     </tr>

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -20,7 +20,7 @@ Releases
 
 Brief notes describing each release and what's new.
 
-Project `milestones <https://github.com/prjemian/hklpy2_solvers/milestones>`_
+Project `milestones <https://github.com/bluesky/hklpy2_solvers/milestones>`_
 describe future plans.
 
 ..
@@ -28,6 +28,11 @@ describe future plans.
     ######
 
     Expected release: tba
+
+    Maintenance
+    ~~~~~~~~~~~
+
+    * Update repo URLs, docs host, and authors for move to ``bluesky`` org.  :issue:`62`
 
 0.3.8
 ######

--- a/docs/source/_static/switcher.json
+++ b/docs/source/_static/switcher.json
@@ -1,6 +1,6 @@
 [
     {
         "version": "latest",
-        "url": "https://prjemian.github.io/hklpy2_solvers/latest/"
+        "url": "https://blueskyproject.io/hklpy2_solvers/latest/"
     }
 ]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -130,7 +130,7 @@ html_theme_options = {
         # across releases, so without this stale entries would linger in
         # browser/CDN caches for up to 10 minutes after a new release.
         "json_url": (
-            "https://prjemian.github.io/hklpy2_solvers/latest/_static/"
+            "https://blueskyproject.io/hklpy2_solvers/latest/_static/"
             f"switcher.json?v={release}"
         ),
         "version_match": switcher_version_match,

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -29,8 +29,8 @@ framework via its entry-point interface.
       :ref:`guides`
       · :ref:`install`
       · :doc:`API <api/hklpy2_solvers/index>`
-      · `documentation <https://prjemian.github.io/hklpy2_solvers>`_
-      · `source <https://github.com/prjemian/hklpy2_solvers>`_
+      · `documentation <https://blueskyproject.io/hklpy2_solvers>`_
+      · `source <https://github.com/bluesky/hklpy2_solvers>`_
       · :ref:`release_notes`
       · :ref:`license`
       · :ref:`genindex`

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -43,7 +43,7 @@ Install for development
 
 .. code-block:: bash
 
-   git clone https://github.com/prjemian/hklpy2_solvers
+   git clone https://github.com/bluesky/hklpy2_solvers
    cd hklpy2_solvers
    pip install -e ".[dev]"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 license = "LicenseRef-UChicago-Argonne-LLC-License"
 license-files = ["LICEN[CS]E*"]
 authors = [
+  { name = "Bluesky Team" },
   { name = "Pete Jemian", email = "prjemian+hklpy2@gmail.com" },
 ]
 maintainers = [{ name = "Pete Jemian", email = "prjemian+hklpy2@gmail.com" }]
@@ -54,9 +55,9 @@ doc = [
 ]
 
 [project.urls]
-homepage = "https://github.com/prjemian/hklpy2_solvers"
-issues = "https://github.com/prjemian/hklpy2_solvers/issues"
-source = "https://github.com/prjemian/hklpy2_solvers"
+homepage = "https://github.com/bluesky/hklpy2_solvers"
+issues = "https://github.com/bluesky/hklpy2_solvers/issues"
+source = "https://github.com/bluesky/hklpy2_solvers"
 
 [project.entry-points."hklpy2.solver"]
 ad_hoc = "hklpy2_solvers.ad_hoc_solver:AdHocSolver"

--- a/tests/test_cross_validation.py
+++ b/tests/test_cross_validation.py
@@ -418,7 +418,7 @@ GROUPS = {
 # hkl`` internally for these cases, so round-trip tests are not
 # xfailed.
 KNOWN_TTH_DISAGREEMENTS = {
-    # https://github.com/prjemian/hklpy2_solvers/issues/68 - libhkl B-matrix
+    # https://github.com/bluesky/hklpy2_solvers/issues/68 - libhkl B-matrix
     # bug for cells with direct alpha != 90 deg; ad_hoc + diffcalc-core
     # agree exactly with each other and with the canonical BL1967 B,
     # libhkl is the outlier.  Affects every cell whose direct alpha
@@ -475,7 +475,7 @@ KNOWN_FORWARD_GAPS = {
     # #284: kappa equivalent-Eulerian chi axis now matches
     # fourcv/fourch/psic).  Those two cases now solve and are covered
     # by the default ``does_not_raise()`` parametrizations.
-    # https://github.com/prjemian/hklpy2_solvers/issues/69 and upstream
+    # https://github.com/bluesky/hklpy2_solvers/issues/69 and upstream
     # https://github.com/BCDA-APS/ad_hoc_diffractometer/issues/285 -
     # three ``ad_hoc`` horizontal-bisecting modes (``fourch bisecting``,
     # ``psic bisecting_vertical``, ``kappa6c bisecting_horizontal``)
@@ -508,11 +508,11 @@ KNOWN_FORWARD_GAPS = {
 # environment.  The structural root cause is still unknown and
 # tracked in :issue:`83`.
 CI_ENV_DEPENDENT_GAPS = {
-    # https://github.com/prjemian/hklpy2_solvers/issues/83
+    # https://github.com/bluesky/hklpy2_solvers/issues/83
     ("kappa_horizontal", "k6c", "triclinic", (0, 0, 6)): "issue #83",
     ("kappa_horizontal", "k6c", "triclinic", (1, 1, 0)): "issue #83",
     ("kappa_horizontal", "kappa4ch", "triclinic", (1, 1, 0)): "issue #83",
-    # https://github.com/prjemian/hklpy2_solvers/issues/99 — ``kappa6c
+    # https://github.com/bluesky/hklpy2_solvers/issues/99 — ``kappa6c
     # bisecting_horizontal`` triclinic (1, 1, 0) solves locally under
     # the current ``ad_hoc_diffractometer >= 0.11.1`` floor (fix landed
     # in 0.11.0), but the conda-forge CI env hits the same K6C


### PR DESCRIPTION
- closes #62

Summary:
- update repo URLs and docs host for the bluesky move
- add Bluesky Team to project authors
- align docs publishing workflow with the bluesky custom-domain pattern

Validation:
- pre-commit run --all-files
- pytest ./tests

Transfer-day checklist:
- [ ] Configure GitHub Pages custom domain for `blueskyproject.io` so `https://blueskyproject.io/hklpy2_solvers/` serves the published docs.
- [ ] Verify `bluesky` org members have publish rights on the `hklpy2_solvers` PyPI project and that trusted publishing still resolves from the new repo.
- [ ] Re-authorize Coveralls for `bluesky/hklpy2_solvers`.
- [ ] Re-authorize DeepWiki for `bluesky/hklpy2_solvers`.
- [ ] Re-verify branch protection and required checks in the new org.
- [ ] Re-add any GitHub Actions secrets required by workflows in the new org.

Agent: OpenCode (gpt54)